### PR TITLE
Use PIN from refresh URI when taking login session

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -301,7 +301,8 @@ static void destroy_key_cache(P11PROV_OBJ *obj, P11PROV_SESSION *session)
     if (session) {
         sess = p11prov_session_handle(session);
     } else {
-        ret = p11prov_take_login_session(obj->ctx, obj->slotid, &_session);
+        ret = p11prov_take_login_session(obj->ctx, obj->slotid,
+                                         obj->refresh_uri, &_session);
         if (ret != CKR_OK) {
             P11PROV_debug("Failed to get login session. Error %lx", ret);
             return;
@@ -369,7 +370,8 @@ static void cache_key(P11PROV_OBJ *obj)
         return;
     }
 
-    ret = p11prov_take_login_session(obj->ctx, obj->slotid, &session);
+    ret = p11prov_take_login_session(obj->ctx, obj->slotid, obj->refresh_uri,
+                                     &session);
     if (ret != CKR_OK || session == NULL) {
         P11PROV_debug("Failed to get login session. Error %lx", ret);
         return;
@@ -3601,7 +3603,7 @@ static CK_RV p11prov_store_rsa_public_key(P11PROV_OBJ *key)
         goto done;
     }
 
-    rv = p11prov_take_login_session(key->ctx, slot, &session);
+    rv = p11prov_take_login_session(key->ctx, slot, key->refresh_uri, &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -3670,7 +3672,7 @@ static CK_RV p11prov_store_ec_public_key(P11PROV_OBJ *key)
         goto done;
     }
 
-    rv = p11prov_take_login_session(key->ctx, slot, &session);
+    rv = p11prov_take_login_session(key->ctx, slot, key->refresh_uri, &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -3858,7 +3860,7 @@ static CK_RV p11prov_store_rsa_private_key(P11PROV_OBJ *key,
         goto done;
     }
 
-    rv = p11prov_take_login_session(key->ctx, slot, &session);
+    rv = p11prov_take_login_session(key->ctx, slot, key->refresh_uri, &session);
     if (rv != CKR_OK) {
         goto done;
     }
@@ -3954,7 +3956,7 @@ static CK_RV p11prov_store_ec_private_key(P11PROV_OBJ *key,
         goto done;
     }
 
-    rv = p11prov_take_login_session(key->ctx, slot, &session);
+    rv = p11prov_take_login_session(key->ctx, slot, key->refresh_uri, &session);
     if (rv != CKR_OK) {
         goto done;
     }

--- a/src/session.c
+++ b/src/session.c
@@ -1045,7 +1045,7 @@ done:
 }
 
 CK_RV p11prov_take_login_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
-                                 P11PROV_SESSION **_session)
+                                 P11PROV_URI *uri, P11PROV_SESSION **_session)
 {
     P11PROV_SLOTS_CTX *slots = NULL;
     P11PROV_SLOT *slot = NULL;
@@ -1071,7 +1071,7 @@ CK_RV p11prov_take_login_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
         goto done;
     }
 
-    ret = slot_login(slot, NULL, NULL, NULL, false, _session);
+    ret = slot_login(slot, uri, NULL, NULL, false, _session);
 
 done:
     p11prov_return_slots(slots);

--- a/src/session.h
+++ b/src/session.h
@@ -18,7 +18,7 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg,
                           bool reqlogin, bool rw, P11PROV_SESSION **session);
 CK_RV p11prov_take_login_session(P11PROV_CTX *provctx, CK_SLOT_ID slotid,
-                                 P11PROV_SESSION **_session);
+                                 P11PROV_URI *uri, P11PROV_SESSION **_session);
 void p11prov_return_session(P11PROV_SESSION *session);
 
 CK_RV p11prov_context_specific_login(P11PROV_SESSION *session, P11PROV_URI *uri,


### PR DESCRIPTION
#### Description

If multiple slots with different PINs are used and the pins are provided in uri using pin-value query param, then it doesn't work, then it might not get correctly the open session. With the current code it's more theoretical as there is not sessions refreshing needed but I saw it when I did session refreshing.

I will think about this more if it really makes sense actually.

<!-- Note: it is best to make pull requests from a branch rather than from main -->

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
