### PR TITLE
Add pkcs11-module-default-slot-id cfg for default slot ID

### DIFF
--- a/docs/provider-pkcs11.7.md
+++ b/docs/provider-pkcs11.7.md
@@ -242,6 +242,23 @@ Example:
 
 ```pkcs11-module-assume-fips = true```
 
+## pkcs11-module-default-slot-id
+
+The default slot ID for new objects.
+
+The default slot is used for any objects that do not have an explicitly
+selected slot. Such objects include, for example, public keys.
+
+This option is useful when multiple slots with different PINs are used. In such
+cases, it allows you to ensure that pkcs11-module-token-pin points to the
+expected slot.
+
+If no value is specified, the first listed slot is used.
+
+Default: none
+
+```pkcs11-module-default-slot-id = 12345```
+
 
 ENVIRONMENT VARIABLES
 =====================

--- a/src/provider.h
+++ b/src/provider.h
@@ -268,6 +268,7 @@ P11PROV_INTERFACE *p11prov_ctx_get_interface(P11PROV_CTX *ctx);
 CK_UTF8CHAR_PTR p11prov_ctx_pin(P11PROV_CTX *ctx);
 OSSL_LIB_CTX *p11prov_ctx_get_libctx(P11PROV_CTX *ctx);
 CK_RV p11prov_ctx_status(P11PROV_CTX *ctx);
+CK_SLOT_ID p11prov_ctx_get_default_slotid(P11PROV_CTX *ctx);
 P11PROV_SLOTS_CTX *p11prov_ctx_get_slots(P11PROV_CTX *ctx);
 void p11prov_ctx_set_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX *slots);
 CK_RV p11prov_ctx_get_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,

--- a/src/slot.c
+++ b/src/slot.c
@@ -173,6 +173,10 @@ CK_RV p11prov_init_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX **slots)
     }
 
     sctx->default_slot = CK_UNAVAILABLE_INFORMATION;
+    CK_SLOT_ID prov_default_slotid =
+        p11prov_ctx_get_default_slotid(sctx->provctx);
+    if (prov_default_slotid != CK_UNAVAILABLE_INFORMATION)
+        sctx->default_slot = prov_default_slotid;
 
     for (size_t i = 0; i < num; i++) {
         P11PROV_SLOT *slot;

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -117,6 +117,9 @@ ptool() {
     if [ -n "$P11DEFLOGIN" ]; then
         CMDOPTS+=("${P11DEFLOGIN[@]}")
     fi
+    if [ -n "$SLOTID" ]; then
+        CMDOPTS+=("--slot=${SLOTID}")
+    fi
     CMDOPTS+=("$@")
     # when running sanitizer tests libasan is linked via pkcs11-provider into
     # openssl and pkcs11-tool is linked to libcrypto, so we need to break the

--- a/tests/kryoptic-init.sh
+++ b/tests/kryoptic-init.sh
@@ -26,10 +26,12 @@ find_kryoptic \
 
 title LINE "Creating Kryoptic database"
 
+SLOTID=${SLOTID:-0}
+
 # Kryoptic configuration
 cat << EOF > "$TOKDIR/kryoptic.conf"
 [[slots]]
-slot = 0
+slot = $SLOTID
 dbtype = "sqlite"
 dbargs = "$TOKDIR/kryoptic.sql"
 #mechanisms
@@ -40,10 +42,11 @@ export TOKENLABEL="${TOKENLABEL:-Kryoptic Token}"
 export TOKENLABELURI="${TOKENLABELURI:-Kryoptic%20Token}"
 
 # init token
-ptool --init-token --label "${TOKENLABEL}" --so-pin "${PINVALUE}" 2>&1
+ptool --init-token --slot "${SLOTID}" --label "${TOKENLABEL}" \
+      --so-pin "${PINVALUE}" 2>&1
 # set user pin
-ptool --so-pin "${PINVALUE}" --login --login-type so --init-pin \
-      --pin "${PINVALUE}" 2>&1
+ptool --so-pin "${PINVALUE}" --slot "${SLOTID}" --login --login-type so \
+      --init-pin --pin "${PINVALUE}" 2>&1
 
 export TOKENCONFIGVARS="export KRYOPTIC_CONF=$TOKDIR/kryoptic.conf"
 

--- a/tests/kryoptic.multislot-init.sh
+++ b/tests/kryoptic.multislot-init.sh
@@ -1,0 +1,65 @@
+#!/bin/bash -ex
+# Copyright (C) 2024 Jakub Zelenka <jakub.openssl@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+
+export SLOTID=42
+export SLOTID2=52
+export TOKEN2LABEL="${TOKENLABEL:-Kryoptic Token 2}"
+export TOKEN2LABELURI="${TOKENLABELURI:-Kryoptic%20Token%202}"
+export PIN2VALUE=11111111
+
+export KRYOPTIC_CONF="${TMPPDIR}/kryoptic.conf"
+cat >"${KRYOPTIC_CONF}" <<_EOF
+[[slots]]
+slot = $SLOTID
+dbtype = "sqlite"
+dbargs = "$TOKDIR/kryoptic.sql"
+#mechanisms
+[[slots]]
+slot = $SLOTID2
+dbtype = "sqlite"
+dbargs = "${TOKDIR}/kryoptic2.sql"
+description = "Kryoptic Token 2"
+_EOF
+
+# this overrides what we define in the generic init
+export TOKENLABEL="Kryoptic Soft Token"
+export TOKENLABELURI="Kryoptic%20Soft%20Token"
+
+# the rest is the same
+source "${TESTSSRCDIR}/kryoptic-init.sh"
+
+# init token 2
+pkcs11-tool --module "${P11LIB}" --init-token --slot "${SLOTID2}" \
+    --label "${TOKEN2LABEL}" --so-pin "${PIN2VALUE}" 2>&1
+# set user pin 2
+pkcs11-tool --module "${P11LIB}" --so-pin "${PIN2VALUE}" --slot "${SLOTID2}" \
+    --login --login-type so --init-pin --pin "${PIN2VALUE}" 2>&1
+
+export TOKENCONFIGVARS="export KRYOPTIC_CONF=${TMPPDIR}/kryoptic.conf"
+export TESTPORT="29000"
+
+# generate RSA key
+KEYID='0201'
+URIKEYID="%02%01"
+
+pkcs11-tool --module "${P11LIB}" --slot "${SLOTID2}" --pin "${PIN2VALUE}" \
+    --keypairgen --key-type="RSA:2048" --id="$KEYID" \
+    --label="testKey" 2>&1
+
+export BASEURI2WITHPINVALUE="pkcs11:id=${URIKEYID}?pin-value=${PINVALUE}"
+export BASEURI2="pkcs11:id=${URIKEYID}"
+export PUBURI2="pkcs11:type=public;id=${URIKEYID}"
+export PRIURI2="pkcs11:type=private;id=${URIKEYID}"
+
+title LINE "RSA PKCS11 URIS"
+echo "${BASEURI2WITHPINVALUE}"
+echo "${BASEURI2}"
+echo "${PUBURI2}"
+echo "${PRIURI2}"
+echo ""
+
+# While this works with the default DB, the NSS DB does not support this
+# attribute
+export SUPPORT_ALLOWED_MECHANISMS=0

--- a/tests/kryoptic.nss-init.sh
+++ b/tests/kryoptic.nss-init.sh
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+export SLOTID=42
+export SLOTSCOUNT=1
+
 export KRYOPTIC_CONF="${TMPPDIR}/kryoptic.conf"
 cat >"${KRYOPTIC_CONF}" <<_EOF
 [[slots]]
-slot = 42
+slot = ${SLOTID}
 dbtype = "nssdb"
 dbargs = "configDir='${TOKDIR}' flags='passwordRequired'"
 description = "Kryoptic Soft Token"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -104,6 +104,7 @@ test_programs = {
   'treadkeys': ['treadkeys.c'],
   'tcmpkeys': ['tcmpkeys.c', 'util.c'],
   'tfork': ['tfork.c', 'util.c'],
+  'tstorepubkey': ['tstorepubkey.c', 'util.c'],
   'tpkey': ['tpkey.c', 'util.c'],
   'pincache': ['pincache.c'],
   'ccerts': ['ccerts.c', 'util.c'],
@@ -123,7 +124,7 @@ endforeach
 
 setup_script=find_program('setup.sh')
 all_suites=['softokn', 'softhsm', 'kryoptic', 'kryoptic.nss']
-foreach suite : all_suites
+foreach suite : all_suites + ['kryoptic.multislot']
   test(
     'setup',
     setup_script,
@@ -169,6 +170,7 @@ tests = {
   'pinlock': {'suites': ['kryoptic']},
   'aead': {'suites': ['softokn', 'kryoptic', 'kryoptic.nss']},
   'op_state': {'suites': all_suites},
+  'defaultslot': {'suites': ['kryoptic.multislot']},
 }
 
 test_wrapper = find_program('test-wrapper')

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -23,6 +23,7 @@ activate = 1
 [pkcs11_sect]
 module = @libtoollibs@/pkcs11@SHARED_EXT@
 pkcs11-module-token-pin = file:@PINFILE@
+#pkcs11-module-default-slot-id
 ##TOKENOPTIONS
 #pkcs11-module-encode-provider-uri-to-pem
 #pkcs11-module-allow-export

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -98,6 +98,8 @@ elif [ "${TOKENTYPE}" == "kryoptic" ]; then
     source "${TESTSSRCDIR}/kryoptic-init.sh"
 elif [ "${TOKENTYPE}" == "kryoptic.nss" ]; then
     source "${TESTSSRCDIR}/kryoptic.nss-init.sh"
+elif [ "${TOKENTYPE}" == "kryoptic.multislot" ]; then
+    source "${TESTSSRCDIR}/kryoptic.multislot-init.sh"
 else
     echo "Unknown token type: $1"
     exit 1
@@ -808,6 +810,16 @@ export RSAPSS2BASEURI="${RSAPSS2BASEURI}"
 export RSAPSS2PUBURI="${RSAPSS2PUBURI}"
 export RSAPSS2PRIURI="${RSAPSS2PRIURI}"
 export RSAPSS2CRTURI="${RSAPSS2CRTURI}"
+DBGSCRIPT
+fi
+
+if [ -n "${PRIURI2}" ]; then
+    cat >> "${TMPPDIR}/testvars" <<DBGSCRIPT
+
+export BASEURI2WITHPINVALUE="${BASEURI2WITHPINVALUE}"
+export BASEURI2="${BASEURI2}"
+export PUBURI2="${PUBURI2}"
+export PRIURI2="${PRIURI2}"
 DBGSCRIPT
 fi
 

--- a/tests/tdefaultslot
+++ b/tests/tdefaultslot
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+# Copyright (C) 2025 Jakub Zelenka <jakub.openssl@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+source "${TESTSSRCDIR}/helpers.sh"
+
+ORIG_OPENSSL_CONF=${OPENSSL_CONF}
+sed -e "s/#pkcs11-module-default-slot-id/pkcs11-module-default-slot-id = 52/" \
+    -e "s/^pkcs11-module-token-pin.*$/pkcs11-module-token-pin = 11111111/" \
+    "${OPENSSL_CONF}" > "${OPENSSL_CONF}.defaultslot"
+export OPENSSL_CONF=${OPENSSL_CONF}.defaultslot
+
+title PARA "Test PKCS11 SLOTS default slot - pub key storing"
+"${TESTBLDDIR}/tstorepubkey" "${PUBURI2}"
+
+title PARA "Test PKCS11 SLOTS default slot - checking slot"
+pkcs11-tool --module "${P11LIB}" --slot 52 -O | grep 'id=%02%01;object=testKey' -q
+
+export OPENSSL_CONF=${ORIG_OPENSSL_CONF}

--- a/tests/tstorepubkey.c
+++ b/tests/tstorepubkey.c
@@ -1,0 +1,76 @@
+/* Copyright (C) 2025 Jakub Zelenka <jakub.openssl@gmail.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/store.h>
+#include <sys/wait.h>
+#include <stdio.h>
+#include "util.h"
+
+int main(int argc, char *argv[])
+{
+    EVP_PKEY *pubkey, *pubkey_main;
+
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <pubkey>\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+
+    const char *pubkey_uri = argv[1];
+
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
+    pubkey_main = load_key_ex(pubkey_uri, "provider=pkcs11");
+    if (!pubkey_main) {
+        exit(EXIT_FAILURE);
+    }
+
+    OSSL_PARAM *params = NULL;
+    EVP_PKEY_CTX *pctx = NULL;
+    int ret;
+
+    ret = EVP_PKEY_todata(pubkey_main, EVP_PKEY_PUBLIC_KEY, &params);
+    if (ret != 1) {
+        PRINTERROSSL("Failed to export key params\n");
+        EVP_PKEY_free(pubkey_main);
+        exit(EXIT_FAILURE);
+    }
+
+    pctx = EVP_PKEY_CTX_new_from_name(
+        NULL, EVP_PKEY_get0_type_name(pubkey_main), "provider=pkcs11");
+    EVP_PKEY_free(pubkey_main);
+    if (!pctx) {
+        PRINTERROSSL("Failed to create fromdata ctx\n");
+        OSSL_PARAM_free(params);
+        exit(EXIT_FAILURE);
+    }
+
+    ret = EVP_PKEY_fromdata_init(pctx);
+    if (ret != 1) {
+        PRINTERROSSL("Failed to init fromdata\n");
+        EVP_PKEY_CTX_free(pctx);
+        OSSL_PARAM_free(params);
+        exit(EXIT_FAILURE);
+    }
+
+    pubkey = NULL;
+    ret = EVP_PKEY_fromdata(pctx, &pubkey, EVP_PKEY_PUBLIC_KEY, params);
+    if (ret != 1) {
+        PRINTERROSSL("Failed to import key via fromdata\n");
+        EVP_PKEY_CTX_free(pctx);
+        OSSL_PARAM_free(params);
+        exit(EXIT_FAILURE);
+    }
+
+    EVP_PKEY_CTX_free(pctx);
+    OSSL_PARAM_free(params);
+
+    EVP_PKEY_free(pubkey);
+
+    exit(EXIT_SUCCESS);
+}

--- a/tests/util.c
+++ b/tests/util.c
@@ -40,7 +40,7 @@ void ossl_err_print(void)
     fflush(stderr);
 }
 
-EVP_PKEY *load_key(const char *uri)
+EVP_PKEY *load_key_ex(const char *uri, const char *propq)
 {
     OSSL_STORE_CTX *store;
     OSSL_STORE_INFO *info;
@@ -52,7 +52,7 @@ EVP_PKEY *load_key(const char *uri)
         exit(EXIT_FAILURE);
     }
 
-    store = OSSL_STORE_open(uri, NULL, NULL, NULL, NULL);
+    store = OSSL_STORE_open_ex(uri, NULL, propq, NULL, NULL, NULL, NULL, NULL);
     if (store == NULL) {
         fprintf(stderr, "Failed to open store: %s\n", uri);
         ossl_err_print();
@@ -98,6 +98,11 @@ EVP_PKEY *load_key(const char *uri)
     OSSL_STORE_close(store);
 
     return key;
+}
+
+EVP_PKEY *load_key(const char *uri)
+{
+    return load_key_ex(uri, NULL);
 }
 
 X509 *load_cert(const char *uri, const UI_METHOD *ui_method, void *ui_data)

--- a/tests/util.h
+++ b/tests/util.h
@@ -18,6 +18,7 @@
     } while (0)
 
 void ossl_err_print(void);
+EVP_PKEY *load_key_ex(const char *uri, const char *propq);
 EVP_PKEY *load_key(const char *uri);
 X509 *load_cert(const char *uri, const UI_METHOD *ui_method, void *ui_data);
 void hexify(char *out, unsigned char *byte, size_t len);


### PR DESCRIPTION
#### Description

There are use cases when one wants to select the default slot id (especially when the first slot ID is not convenient for this purpose) which is used for example for storing public keys.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
