### PR TITLE
Require login for session when getting private assoc key

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -1453,8 +1453,8 @@ P11PROV_OBJ *p11prov_obj_find_associated(P11PROV_OBJ *obj,
     slotid = p11prov_obj_get_slotid(obj);
 
     ret = p11prov_get_session(obj->ctx, &slotid, NULL, NULL,
-                              CK_UNAVAILABLE_INFORMATION, NULL, NULL, false,
-                              false, &session);
+                              CK_UNAVAILABLE_INFORMATION, NULL, NULL,
+                              class == CKO_PRIVATE_KEY, false, &session);
     if (ret != CKR_OK) {
         goto done;
     }


### PR DESCRIPTION
#### Description

This is a fix for #610 to require login if search associated object class is `CKO_PRIVATE_KEY`

I was looking into implementing a test but it seems quite tricky to create a key pair where only private key has the mechanisms attribute set but public key doesn't - I'm not sure if that's even possible using pkcs11-tool?

Alternativelly I could just do a grep from the debug log to see if there is that reported error which should be relatively simple.

Or if you are fine to get this merged without test, then it's ready as it is.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
- [ ] Coverity Scan has run if needed (code PR) and no new defects were found
