### PR TITLE
obj: Do not assume CKR_ATTRIBUTE_TYPE_INVALID means the token does no…

### DIFF
--- a/src/obj/fetch.c
+++ b/src/obj/fetch.c
@@ -443,11 +443,6 @@ CK_RV p11prov_obj_from_handle(P11PROV_CTX *ctx, P11PROV_SESSION *session,
             if (ret == CKR_OK) {
                 obj->attrs[obj->numattrs] = a[0].attr;
                 obj->numattrs++;
-            } else if (ret == CKR_ATTRIBUTE_TYPE_INVALID) {
-                token_supports_allowed_mechs = CK_FALSE;
-                (void)p11prov_token_sup_attr(ctx, obj->slotid, SET_ATTR,
-                                             CKA_ALLOWED_MECHANISMS,
-                                             &token_supports_allowed_mechs);
             }
         }
         break;


### PR DESCRIPTION
…t support the attribute at all

This return code means just the attribute is not present on the CURRENT object so assuming from this return code that this attribute is not supported at all is wrong and was just accidentally working for kryoptic, because we did not return the correct value when searching for attributes:

https://github.com/latchset/kryoptic/pull/436

#### Description

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about year later when sorting thorough as commits are the changelog.
-->

<!-- Note: it is best to make pull requests from a branch rather than from main -->

#### Checklist

- [X] Code modified for feature
- [~] Test suite updated with functionality tests
- [~] Test suite updated with negative tests
- [~] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
