### PR TITLE
Add failure test logs for coverage job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,6 +37,17 @@ jobs:
           ninja -C builddir coverage
 
       - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: Coverage test logs
+          path: |
+            builddir/meson-logs/
+            builddir/tests/*.log
+            builddir/tests/softokn/
+            builddir/tests/softhsm/
+            builddir/tests/kryoptic/
+
+      - uses: actions/upload-artifact@v7
         with:
           name: Test coverage reports
           path: |


### PR DESCRIPTION
#### Description

This is to see failures if coverage job fails like it's happening in #536