### PR TITLE
Asan workaround

### DIFF
--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -18,7 +18,7 @@ jobs:
         # , debian]
         include:
           - name: fedora
-            container: quay.io/fedora/fedora:latest
+            container: quay.io/fedora/fedora:rawhide
         #  - name: debian
         #    container: debian:sid
     container: ${{ matrix.container }}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -85,7 +85,7 @@ if get_option('b_sanitize') == 'address'
   add_env = {
     'ASAN_OPTIONS': 'fast_unwind_on_malloc=0:detect_leaks=1',
     'LSAN_OPTIONS': 'suppressions=@0@/lsan.supp'.format(meson.current_source_dir()),
-    'FAKE_DLCLOSE': fake_dlclose.full_path(),
+    'OPENSC_DEEPBIND': '0',
     'CHECKER': checker,
   }
 


### PR DESCRIPTION
#### Description

Workaround for change in OpenSC forcing the use of RTLD_DEEPBIND in dlopen().

The respective build for Fedora rawhide:

https://koji.fedoraproject.org/koji/taskinfo?taskID=144902342

And respective fix in OpenSC:

https://github.com/OpenSC/OpenSC/pull/3670/

#### Checklist

- [X] No Code modified for feature

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
