### PR TITLE
Attempt to avoid using libasan with pkcs11-tool which now uses DEEPBIND

### DIFF
--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -110,10 +110,22 @@ fi
 ptool() {
     # NSS uses the second slot for certificates, so we need to provide the token
     # label in the args to allow pkcs11-tool to find the right slot
-    CMDOPTS=(--module="${P11LIB}" --token-label="${TOKENLABEL}")
+    CMDOPTS=(--module="${P11LIB}")
+    if [[ ! " $* " == *" --init-token "* ]]; then
+        CMDOPTS+=(--token-label="${TOKENLABEL}")
+    fi
     if [ -n "$P11DEFLOGIN" ]; then
         CMDOPTS+=("${P11DEFLOGIN[@]}")
     fi
     CMDOPTS+=("$@")
-    $CHECKER pkcs11-tool "${CMDOPTS[@]}"
+    # when running sanitizer tests libasan is linked via pkcs11-provider into
+    # openssl and pkcs11-tool is linked to libcrypto, so we need to break the
+    # link
+    ORIG_OPENSSL_CONF=${OPENSSL_CONF}
+    unset OPENSSL_CONF
+    ORIG_LD_PRELOAD=${LD_PRELOAD}
+    unset LD_PRELOAD
+    pkcs11-tool "${CMDOPTS[@]}"
+    export OPENSSL_CONF=${ORIG_OPENSSL_CONF}
+    export LD_PRELOAD=${ORIG_LD_PRELOAD}
 }

--- a/tests/kryoptic-init.sh
+++ b/tests/kryoptic-init.sh
@@ -8,7 +8,7 @@ find_kryoptic() {
     for _lib in "$@" ; do
         if test -f "$_lib" ; then
             echo "Using kryoptic path $_lib"
-            P11LIB="$_lib"
+            export P11LIB="${_lib}"
             return
         fi
     done
@@ -40,11 +40,10 @@ export TOKENLABEL="${TOKENLABEL:-Kryoptic Token}"
 export TOKENLABELURI="${TOKENLABELURI:-Kryoptic%20Token}"
 
 # init token
-pkcs11-tool --module "${P11LIB}" --init-token \
-    --label "${TOKENLABEL}" --so-pin "${PINVALUE}" 2>&1
+ptool --init-token --label "${TOKENLABEL}" --so-pin "${PINVALUE}" 2>&1
 # set user pin
-pkcs11-tool --module "${P11LIB}" --so-pin "${PINVALUE}" \
-    --login --login-type so --init-pin --pin "${PINVALUE}" 2>&1
+ptool --so-pin "${PINVALUE}" --login --login-type so --init-pin \
+      --pin "${PINVALUE}" 2>&1
 
 export TOKENCONFIGVARS="export KRYOPTIC_CONF=$TOKDIR/kryoptic.conf"
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -85,7 +85,6 @@ if get_option('b_sanitize') == 'address'
   add_env = {
     'ASAN_OPTIONS': 'fast_unwind_on_malloc=0:detect_leaks=1',
     'LSAN_OPTIONS': 'suppressions=@0@/lsan.supp'.format(meson.current_source_dir()),
-    'FAKE_DLCLOSE': fake_dlclose.full_path(),
     'CHECKER': checker,
   }
 

--- a/tests/tpinlock
+++ b/tests/tpinlock
@@ -24,7 +24,12 @@ fi
 # Kryoptic allows for 10 tries by default
 for i in {1..10}; do
     echo "Login attempt: $i"
-    ptool -l -I -p "${BADPIN}" && false
+    FAIL=1
+    ptool -l -I -p "${BADPIN}" || FAIL=0
+    if [ $FAIL -eq 0 ]; then
+        echo "Should have failed!"
+        exit 1
+    fi
     DETECT=0
     ptool -T | grep "final user PIN try" && DETECT=1
     if [ $DETECT -eq 1 ]; then


### PR DESCRIPTION
#### Description

Asan can't currently work with RTLD_DEEPBIND flags at dlopen() time, and it let's you know by terminating the process.

We use opensc tools only during setup, and they recently changed to use RTLD_DEEPBIND when opening pkcs11 modules, so we should be able to deal with address sanitizer by simply excluding it during setup.

Token setup via pkcs11-tools uses no pkcs11-provider code so we do not care for running the sanitizer on those actions.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] This is not a code change
- [x] Test suite changed

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
