### PR TITLE
Avoid code scan false positives

### DIFF
--- a/src/sig/ecdsa.c
+++ b/src/sig/ecdsa.c
@@ -82,7 +82,7 @@ struct ecdsa_data {
     { CK_UNAVAILABLE_INFORMATION, 0, NULL, 0 },
 };
 
-static struct ecdsa_data *ecdsa_digest_map(CK_MECHANISM_TYPE digest)
+static const struct ecdsa_data *ecdsa_digest_map(CK_MECHANISM_TYPE digest)
 {
     for (int i = 0; ecdsa_mech_map[i].digest != CK_UNAVAILABLE_INFORMATION;
          i++) {
@@ -102,7 +102,7 @@ static CK_RV p11prov_ecdsa_set_mechanism(P11PROV_SIG_CTX *sigctx)
     switch (sigctx->mechtype) {
     case CKM_ECDSA:
         if (sigctx->digest_op) {
-            struct ecdsa_data *data;
+            const struct ecdsa_data *data;
             data = ecdsa_digest_map(sigctx->digest);
             if (!data) {
                 return CKR_MECHANISM_INVALID;
@@ -545,7 +545,7 @@ static int p11prov_ecdsa_get_ctx_params(void *ctx, OSSL_PARAM *params)
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
     if (p) {
-        struct ecdsa_data *data;
+        const struct ecdsa_data *data;
         data = ecdsa_digest_map(sigctx->digest);
         if (!data) {
             return RET_OSSL_ERR;

--- a/src/sig/rsasig.c
+++ b/src/sig/rsasig.c
@@ -159,7 +159,7 @@ struct rsasig_data {
     { CK_UNAVAILABLE_INFORMATION, 0, 0, 0, NULL, 0, NULL, 0, NULL, 0 },
 };
 
-static struct rsasig_data *rsasig_digest_map(CK_MECHANISM_TYPE digest)
+static const struct rsasig_data *rsasig_digest_map(CK_MECHANISM_TYPE digest)
 {
     for (int i = 0; rsasig_mech_map[i].digest != CK_UNAVAILABLE_INFORMATION;
          i++) {
@@ -170,7 +170,7 @@ static struct rsasig_data *rsasig_digest_map(CK_MECHANISM_TYPE digest)
     return NULL;
 }
 
-static struct rsasig_data *rsasig_mgf_map(CK_MECHANISM_TYPE mgf)
+static const struct rsasig_data *rsasig_mgf_map(CK_MECHANISM_TYPE mgf)
 {
     for (int i = 0; rsasig_mech_map[i].digest != CK_UNAVAILABLE_INFORMATION;
          i++) {
@@ -181,7 +181,7 @@ static struct rsasig_data *rsasig_mgf_map(CK_MECHANISM_TYPE mgf)
     return NULL;
 }
 
-static struct rsasig_data *rsasig_pss_map(CK_MECHANISM_TYPE pssmech)
+static const struct rsasig_data *rsasig_pss_map(CK_MECHANISM_TYPE pssmech)
 {
     for (int i = 0; rsasig_mech_map[i].digest != CK_UNAVAILABLE_INFORMATION;
          i++) {
@@ -194,7 +194,7 @@ static struct rsasig_data *rsasig_pss_map(CK_MECHANISM_TYPE pssmech)
 
 static const char *p11prov_sig_mgf_name(CK_RSA_PKCS_MGF_TYPE mgf)
 {
-    struct rsasig_data *data;
+    const struct rsasig_data *data;
     const char *digest_name;
     CK_RV rv;
 
@@ -214,7 +214,7 @@ static const char *p11prov_sig_mgf_name(CK_RSA_PKCS_MGF_TYPE mgf)
 static CK_RSA_PKCS_MGF_TYPE p11prov_sig_map_mgf(const char *digest_name)
 {
     CK_MECHANISM_TYPE digest;
-    struct rsasig_data *data;
+    const struct rsasig_data *data;
     CK_RV rv;
 
     rv = p11prov_digest_get_by_name(digest_name, &digest);
@@ -288,7 +288,7 @@ static CK_RV p11prov_sig_pss_restrictions(P11PROV_SIG_CTX *sigctx,
 /* fixates pss_params based on defaults if values are not set */
 static CK_RV pss_defaults(P11PROV_SIG_CTX *sigctx)
 {
-    struct rsasig_data *data;
+    const struct rsasig_data *data;
 
     data = rsasig_digest_map(sigctx->digest);
     if (!data) {
@@ -402,23 +402,20 @@ DISPATCH_RSASIG_FN(settable_ctx_params);
 
 static CK_RV p11prov_rsasig_set_mechanism(P11PROV_SIG_CTX *sigctx)
 {
-    struct rsasig_data *data = NULL;
+    const struct rsasig_data *data = NULL;
     int rv;
 
     sigctx->mechanism.mechanism = sigctx->mechtype;
     sigctx->mechanism.pParameter = NULL;
     sigctx->mechanism.ulParameterLen = 0;
 
-    if (sigctx->digest_op) {
-        data = rsasig_digest_map(sigctx->digest);
-        if (!data) {
-            return CKR_MECHANISM_INVALID;
-        }
-    }
-
     switch (sigctx->mechtype) {
     case CKM_RSA_PKCS:
         if (sigctx->digest_op) {
+            data = rsasig_digest_map(sigctx->digest);
+            if (!data) {
+                return CKR_MECHANISM_INVALID;
+            }
             sigctx->mechanism.mechanism = data->pkcs_mech;
         }
         break;
@@ -432,6 +429,10 @@ static CK_RV p11prov_rsasig_set_mechanism(P11PROV_SIG_CTX *sigctx)
         sigctx->mechanism.pParameter = &sigctx->pss_params;
         sigctx->mechanism.ulParameterLen = sizeof(sigctx->pss_params);
         if (sigctx->digest_op) {
+            data = rsasig_digest_map(sigctx->digest);
+            if (!data) {
+                return CKR_MECHANISM_INVALID;
+            }
             sigctx->mechanism.mechanism = data->pkcs_pss;
             rv = p11prov_sig_pss_restrictions(sigctx, data->pkcs_pss);
             if (rv != CKR_OK) {
@@ -463,7 +464,7 @@ static CK_RV p11prov_rsasig_encode_data(P11PROV_SIG_CTX *sigctx,
                                         unsigned char *data, size_t *datalen,
                                         unsigned char *tbs, size_t tbslen)
 {
-    struct rsasig_data *rsa_data;
+    const struct rsasig_data *rsa_data;
     size_t digest_size = 0;
     CK_RV rv;
 
@@ -835,7 +836,7 @@ p11prov_encode_rsa_pss_algorithm_id(CK_MECHANISM_TYPE digest, int saltlen,
                                     size_t *outlen)
 {
     unsigned char *buffer = NULL;
-    struct rsasig_data *data;
+    const struct rsasig_data *data;
 
     data = rsasig_digest_map(digest);
     if (!data) {
@@ -858,7 +859,7 @@ p11prov_encode_rsa_pss_algorithm_id(CK_MECHANISM_TYPE digest, int saltlen,
 static unsigned char *
 p11prov_rsapss_encode_algorithm_id(P11PROV_SIG_CTX *sigctx, size_t *outlen)
 {
-    struct rsasig_data *data, *mgf_data;
+    const struct rsasig_data *data, *mgf_data;
     int ret;
 
     /* when OpenSSL calls this before it makes the signature, we still might not
@@ -914,7 +915,7 @@ static int p11prov_rsasig_get_ctx_params(void *ctx, OSSL_PARAM *params)
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
     if (p) {
         unsigned char *algorithm_id = NULL;
-        struct rsasig_data *data;
+        const struct rsasig_data *data;
         size_t len;
 
         switch (sigctx->mechtype) {
@@ -998,7 +999,7 @@ static int p11prov_rsasig_get_ctx_params(void *ctx, OSSL_PARAM *params)
         if (sigctx->pss_params.mgf != 0) {
             digest = p11prov_sig_mgf_name(sigctx->pss_params.mgf);
         } else {
-            struct rsasig_data *data;
+            const struct rsasig_data *data;
             data = rsasig_pss_map(sigctx->mechtype);
             if (data) {
                 rv = p11prov_digest_get_name(data->digest, &digest);
@@ -1321,7 +1322,7 @@ DEFINE_RSA_SHA_SIG(sha3_512, "SHA3-512");
 
 CK_MECHANISM_TYPE p11prov_digest_to_rsapss_mech(CK_MECHANISM_TYPE digest)
 {
-    struct rsasig_data *data;
+    const struct rsasig_data *data;
 
     data = rsasig_digest_map(digest);
     if (!data) {


### PR DESCRIPTION
#### Description

This commit should prevent the false positives raise for example on PR #726 
The code is fine but for some reason the scan assumes data can be empty even though the same guards cover both usages ... Change the code around so code scan doesn't trip. this does not change the code behavior.

Also add some consts to make the compiler raise warnings if we modify static structures that should never be touched.


#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Cosmetic change


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
