### PR TITLE
encoder: check rsakey for NULL before dereferencing

### DIFF
--- a/src/encoder.c
+++ b/src/encoder.c
@@ -177,6 +177,9 @@ CK_RV rsa_pkeyinfo_to_attrs(CK_ATTRIBUTE *pkeyinfo, CK_ATTRIBUTE *attrs)
     CK_RV rv = CKR_GENERAL_ERROR;
 
     rsakey = decode_rsa_pubkey(pkeyinfo);
+    if (!rsakey) {
+        return CKR_KEY_INDIGESTIBLE;
+    }
 
     n = ASN1_INTEGER_to_BN(rsakey->n, NULL);
     e = ASN1_INTEGER_to_BN(rsakey->e, NULL);


### PR DESCRIPTION
#### Description

decode_rsa_pubkey() returns NULL if d2i_X509_PUBKEY() fails. Check the value before attempting to dereference it.

This got caught by a static analysis run that Siteshwar Vashisht posted to the Fedora development list.

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
