### PR TITLE
doc: Correct example for token-pin in a file

### DIFF
--- a/docs/provider-pkcs11.7.md
+++ b/docs/provider-pkcs11.7.md
@@ -345,7 +345,7 @@ openssl.cnf:
     [pkcs11_sect]
     module = /usr/lib64/ossl-modules/pkcs11.so
     pkcs11-module-path = /usr/lib64/pkcs11/vendor_pkcs11.so
-    pkcs11-module-token-pin = /etc/ssl/pinfile.txt
+    pkcs11-module-token-pin = file:/etc/ssl/pinfile.txt
     activate = 1
 
 


### PR DESCRIPTION
#### Description

The example for pkcs11-module-token-pin was missing the "file:" prefix.

#### Checklist

- [ ] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [x] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
