### PR TITLE
Bind X509 decoding to library context

### DIFF
--- a/src/obj/export.c
+++ b/src/obj/export.c
@@ -33,9 +33,15 @@ CK_RV get_attrs_from_cert(P11PROV_OBJ *crt, CK_ATTRIBUTE *attrs, int num)
         return CKR_GENERAL_ERROR;
     }
 
+    x509 = X509_new_ex(p11prov_ctx_get_libctx(crt->ctx),
+                       "?" P11PROV_DEFAULT_PROVIDER);
+    if (x509 == NULL) {
+        return CKR_GENERAL_ERROR;
+    }
+
     val = value->pValue;
-    x509 = d2i_X509(NULL, &val, value->ulValueLen);
-    if (!x509) {
+    if (d2i_X509(&x509, &val, value->ulValueLen) == NULL) {
+        /* x509 is freed by d2i_X509 on error */
         return CKR_GENERAL_ERROR;
     }
 

--- a/src/provider.h
+++ b/src/provider.h
@@ -38,6 +38,7 @@
 
 #define P11PROV_DEFAULT_PROPERTIES "provider=pkcs11"
 #define P11PROV_FIPS_PROPERTIES "provider=pkcs11,fips=yes"
+#define P11PROV_DEFAULT_PROVIDER "provider=default"
 
 #define P11PROV_NAME_RSA "RSA"
 #define P11PROV_NAMES_RSA "RSA:rsaEncryption:1.2.840.113549.1.1.1"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -166,7 +166,7 @@ tests = {
   'readkeys': {'suites': all_suites},
   'tls': {'suites': all_suites, 'is_parallel': false, 'timeout': 60},
   'tlsfuzzer': {'suites': all_suites, 'timeout': 90},
-  'uri': {'suites': all_suites, 'timeout': 90},
+  'uri': {'suites': ['softokn', 'kryoptic', 'kryoptic.nss'], 'timeout': 90},
   'ecxc': {'suites': ['softhsm', 'kryoptic', 'kryoptic.nss']},
   'cms': {'suites': ['softokn', 'kryoptic', 'kryoptic.nss']},
   'pinlock': {'suites': ['kryoptic']},


### PR DESCRIPTION
#### Description

Pre-allocate the X509 object using X509_new_ex with the current library context and a default provider property query before calling d2i_X509. This ensures certificate decoding is properly associated with the specific OpenSSL library context rather than relying on the global default, preventing provider resolution issues.

Related to #742

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
