### PR TITLE
Allow the user type to be set from configuration

### DIFF
--- a/docs/provider-pkcs11.7
+++ b/docs/provider-pkcs11.7
@@ -165,6 +165,9 @@ immediately at application startup)
 .SS pkcs11\-module\-quirks
 Workarounds that may be needed to deal with some tokens and cannot be
 autodetcted yet are not appropriate defaults.
+.SS luna\-non\-standard\-cku\-user
+Use the non-standard Crypto User (user type 0x80000001) available in
+Thales Luna HSMs instead of the normal Crypto Officer (CKU_USER).
 .SS no\-deinit
 It prevents de\-initing when OpenSSL winds down the provider.
 NOTE this option may leak memory and may cause some modules to misbehave

--- a/docs/provider-pkcs11.7.md
+++ b/docs/provider-pkcs11.7.md
@@ -182,6 +182,10 @@ Example:
 Workarounds that may be needed to deal with some tokens and cannot be
 autodetcted yet are not appropriate defaults.
 
+### luna-non-standard-cku-user
+Use the non-standard Crypto User (user type 0x80000001) available in
+Thales Luna HSMs instead of the normal Crypto Officer (CKU_USER).
+
 ### no-deinit
 It prevents de-initing when OpenSSL winds down the provider.
 NOTE this option may leak memory and may cause some modules to

--- a/src/provider.c
+++ b/src/provider.c
@@ -41,6 +41,7 @@ struct p11prov_ctx {
     bool no_deinit;
     bool no_allowed_mechanisms;
     bool no_session_callbacks;
+    CK_USER_TYPE user_type;
     uint64_t blocked_calls;
     bool blocked_ops[OSSL_OP__HIGHEST + 1];
 
@@ -536,6 +537,11 @@ CK_RV p11prov_ctx_status(P11PROV_CTX *ctx)
 CK_UTF8CHAR_PTR p11prov_ctx_pin(P11PROV_CTX *ctx)
 {
     return (CK_UTF8CHAR_PTR)ctx->pin;
+}
+
+CK_USER_TYPE p11prov_ctx_user_type(P11PROV_CTX *ctx)
+{
+    return ctx->user_type;
 }
 
 static void p11prov_ctx_free(P11PROV_CTX *ctx)
@@ -1825,6 +1831,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
         return RET_OSSL_ERR;
     }
     ctx->handle = handle;
+    ctx->user_type = CKU_USER;
 
     P11PROV_debug("Starting provider %s %d.%d", PACKAGE_NAME, PACKAGE_MAJOR,
                   PACKAGE_MINOR);
@@ -1982,6 +1989,10 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
             } else if (strncmp(str, "no-session-callbacks", toklen) == 0) {
                 show_quirks = true;
                 ctx->no_session_callbacks = true;
+            } else if (strncmp(str, "luna-non-standard-cku-user", toklen)
+                       == 0) {
+                show_quirks = true;
+                ctx->user_type = CKU_LUNA_CU;
             }
             len -= toklen;
             if (sep) {
@@ -2002,6 +2013,9 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
         }
         if (ctx->no_session_callbacks) {
             P11PROV_debug(" No session callbacks");
+        }
+        if (ctx->user_type != CKU_USER) {
+            P11PROV_debug(" Vendor user type: [%08x]", ctx->user_type);
         }
         if (ctx->blocked_calls) {
             P11PROV_debug(" Blocked calls: [%08lx]", ctx->blocked_calls);

--- a/src/provider.h
+++ b/src/provider.h
@@ -281,6 +281,9 @@ CK_RV p11prov_ctx_set_quirk(P11PROV_CTX *ctx, CK_SLOT_ID id, const char *name,
 CK_RV p11prov_token_sup_attr(P11PROV_CTX *ctx, CK_SLOT_ID id, int action,
                              CK_ATTRIBUTE_TYPE attr, CK_BBOOL *data);
 
+#define CKU_LUNA_CU 0x80000001UL
+CK_USER_TYPE p11prov_ctx_user_type(P11PROV_CTX *ctx);
+
 #define ALLOW_EXPORT_PUBLIC 0
 #define DISALLOW_EXPORT_PUBLIC 1
 int p11prov_ctx_allow_export(P11PROV_CTX *ctx);

--- a/src/session.c
+++ b/src/session.c
@@ -592,7 +592,7 @@ static CK_RV token_login(P11PROV_SESSION *session, P11PROV_URI *uri,
     ret = p11prov_Login(session->provctx, session->session, user_type, pin,
                         pinlen);
     if (ret == CKR_OK) {
-        if (user_type == CKU_USER) {
+        if (user_type == p11prov_ctx_user_type(session->provctx)) {
             p11prov_session_ref(session);
             session->is_login = true;
         }
@@ -919,7 +919,8 @@ static CK_RV slot_login(P11PROV_SLOT *slot, P11PROV_URI *uri,
         /* we seem to already have a valid logged in session */
         ret = CKR_OK;
     } else {
-        ret = token_login(session, uri, pw_cb, pw_cbarg, slot, CKU_USER);
+        ret = token_login(session, uri, pw_cb, pw_cbarg, slot,
+                          p11prov_ctx_user_type(session->provctx));
     }
 
 done:


### PR DESCRIPTION
#### Description

Thales Luna HSMs define a vendor specific user type called Crypto User with (numerical 0x80000001) that can create signatures but not manage keys.  Make it possible to use such roles by making the user type configurable.


#### Checklist

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [x] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [x] This feature/change has adequate documentation added
- [x] Code conform to coding style that today cannot yet be enforced via the check style test
- [x] Commits have short titles and sensible commit messages
