### PR TITLE
Correct format specifier for user type

### DIFF
--- a/src/provider.c
+++ b/src/provider.c
@@ -2015,7 +2015,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
             P11PROV_debug(" No session callbacks");
         }
         if (ctx->user_type != CKU_USER) {
-            P11PROV_debug(" Vendor user type: [%08x]", ctx->user_type);
+            P11PROV_debug(" Vendor user type: [%08lx]", ctx->user_type);
         }
         if (ctx->blocked_calls) {
             P11PROV_debug(" Blocked calls: [%08lx]", ctx->blocked_calls);


### PR DESCRIPTION
#### Description

Update the debug format string for ctx->user_type from %08x to %08lx to correctly match the underlying data type and resolve a format string mismatch.

Fixes CID 648609

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for bug
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
