### PR TITLE
Safely extract and null-terminate URI string

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -52,13 +52,29 @@ static int obj_desc_verify(P11PROV_PK11_URI *obj)
 
 static char *obj_uri_get1(P11PROV_PK11_URI *obj)
 {
-    const unsigned char *uri = ASN1_STRING_get0_data(obj->uri);
-    int uri_len = ASN1_STRING_length(obj->uri);
-    if (!uri || uri_len <= 0) {
-        P11PROV_debug("Failed to get URI");
+    unsigned char *uri = NULL;
+    char *ret = NULL;
+
+    if (obj->uri == NULL) {
         return NULL;
     }
-    return p11prov_alloc_sprintf(uri_len, "%*s", uri_len, uri);
+    int uri_len = ASN1_STRING_length(obj->uri);
+    if (uri_len <= 0) {
+        goto done;
+    }
+    uri = OPENSSL_malloc(uri_len + 1);
+    if (uri == NULL) {
+        goto done;
+    }
+    memcpy(uri, ASN1_STRING_get0_data(obj->uri), uri_len);
+    uri[uri_len] = '\0';
+    ret = p11prov_alloc_sprintf(uri_len, "%s", uri);
+done:
+    if (ret == NULL) {
+        P11PROV_debug("Failed to extract URI");
+    }
+    OPENSSL_free(uri);
+    return ret;
 }
 
 struct desired_data_type_cbdata {


### PR DESCRIPTION
#### Description

The `obj_uri_get1` function previously passed raw ASN1 string data to formatting functions. Because ASN1 strings are not guaranteed to be null- terminated, this could lead to out-of-bounds reads.

This update allocates a temporary buffer, explicitly null-terminates the copied string before formatting, and adds a safeguard against a null `obj->uri` pointer to ensure memory safety.

Fixes https://github.com/openssl/openssl/issues/32156

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
