### PR TITLE
Add DIGEST_SIGN and DIGEST_VERIFY to SLH-DSA

### DIFF
--- a/src/sig/slhdsa.c
+++ b/src/sig/slhdsa.c
@@ -676,9 +676,11 @@ static const OSSL_PARAM *p11prov_slhdsa_settable_ctx_params(void *ctx,
         DISPATCH_SIG_ELEM(slhdsa, VERIFY_INIT, verify_init), \
         DISPATCH_SIG_ELEM(slhdsa, VERIFY, verify), \
         DISPATCH_SIG_ELEM(slhdsa, DIGEST_SIGN_INIT, digest_sign_init), \
+        DISPATCH_SIG_ELEM(slhdsa, DIGEST_SIGN, sign), \
         DISPATCH_SIG_ELEM(slhdsa, DIGEST_SIGN_UPDATE, digest_sign_update), \
         DISPATCH_SIG_ELEM(slhdsa, DIGEST_SIGN_FINAL, digest_sign_final), \
         DISPATCH_SIG_ELEM(slhdsa, DIGEST_VERIFY_INIT, digest_verify_init), \
+        DISPATCH_SIG_ELEM(slhdsa, DIGEST_VERIFY, verify), \
         DISPATCH_SIG_ELEM(slhdsa, DIGEST_VERIFY_UPDATE, digest_verify_update), \
         DISPATCH_SIG_ELEM(slhdsa, DIGEST_VERIFY_FINAL, digest_verify_final), \
         DISPATCH_MESSAGE_FUNCTIONS DISPATCH_SIG_ELEM(slhdsa, GET_CTX_PARAMS, \


### PR DESCRIPTION
#### Description

This adds the missing one-shot DIGEST_SIGN and DIGEST_VERIFY operations to the SLH-DSA signature dispatch table. It enables direct digest signing and verification capabilities for SLH-DSA within the provider by mapping them to the existing sign and verify functions.

Fixes #760

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
