### PR TITLE
Fix ambiguous decoding of raw Edwards and Montgomery EC points

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,7 @@ pkcs11_provider_sources = [
   'interface.c',
   'registration.c',
   'obj/create.c',
+  'obj/ec_point.c',
   'obj/export.c',
   'obj/keymgmt.c',
   'obj/fetch.c',

--- a/src/obj/ec_point.c
+++ b/src/obj/ec_point.c
@@ -1,0 +1,94 @@
+/* Copyright (C) 2026 Mounir IDRASSI
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <limits.h>
+#include <stdbool.h>
+#include <openssl/asn1.h>
+#include <openssl/crypto.h>
+
+#include "ec_point.h"
+
+CK_RV p11prov_decode_ec_point_value(CK_KEY_TYPE key_type,
+                                    CK_ULONG expected_size,
+                                    const CK_ATTRIBUTE *attr,
+                                    unsigned char **decoded,
+                                    size_t *decoded_len)
+{
+    ASN1_OCTET_STRING *octet = NULL;
+    const unsigned char *value;
+    const unsigned char *value_end;
+    const unsigned char *point = NULL;
+    size_t point_len = 0;
+    int asn1_len;
+    bool is_ecx;
+    CK_RV ret = CKR_KEY_INDIGESTIBLE;
+
+    if (attr == NULL || decoded == NULL || decoded_len == NULL) {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    *decoded = NULL;
+    *decoded_len = 0;
+
+    is_ecx = key_type == CKK_EC_EDWARDS || key_type == CKK_EC_MONTGOMERY;
+    if (key_type != CKK_EC && !is_ecx) {
+        return CKR_KEY_TYPE_INCONSISTENT;
+    }
+    if (is_ecx
+        && (expected_size == 0
+            || expected_size == CK_UNAVAILABLE_INFORMATION)) {
+        return CKR_KEY_INDIGESTIBLE;
+    }
+
+    if (attr->pValue == NULL || attr->ulValueLen == 0
+        || attr->ulValueLen > (CK_ULONG)LONG_MAX) {
+        return CKR_KEY_INDIGESTIBLE;
+    }
+
+    /*
+     * PKCS#11 3.1 and later specify raw CKA_EC_POINT values for Edwards and
+     * Montgomery keys. Check the expected raw size before trying DER because
+     * arbitrary public-key bytes can accidentally form a valid DER prefix.
+     */
+    if (is_ecx && attr->ulValueLen == expected_size) {
+        point = attr->pValue;
+        point_len = attr->ulValueLen;
+        goto done;
+    }
+
+    value = attr->pValue;
+    value_end = value + attr->ulValueLen;
+    octet = d2i_ASN1_OCTET_STRING(NULL, &value, (long)attr->ulValueLen);
+    if (octet == NULL || (is_ecx && value != value_end)) {
+        goto done;
+    }
+
+    asn1_len = ASN1_STRING_length(octet);
+    if (asn1_len <= 0) {
+        goto done;
+    }
+    point_len = (size_t)asn1_len;
+
+    /*
+     * Retain compatibility with modules that DER OCTET STRING-wrap ECX
+     * points, but reject a decoded value that does not match the selected
+     * curve.
+     */
+    if (is_ecx && point_len != expected_size) {
+        goto done;
+    }
+    point = ASN1_STRING_get0_data(octet);
+
+done:
+    if (point != NULL) {
+        *decoded = OPENSSL_memdup(point, point_len);
+        if (*decoded == NULL) {
+            ret = CKR_HOST_MEMORY;
+        } else {
+            *decoded_len = point_len;
+            ret = CKR_OK;
+        }
+    }
+    ASN1_OCTET_STRING_free(octet);
+    return ret;
+}

--- a/src/obj/ec_point.h
+++ b/src/obj/ec_point.h
@@ -1,0 +1,17 @@
+/* Copyright (C) 2026 Mounir IDRASSI
+   SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef _OBJ_EC_POINT_H_
+#define _OBJ_EC_POINT_H_
+
+#include <stddef.h>
+
+#include "pkcs11.h"
+
+CK_RV p11prov_decode_ec_point_value(CK_KEY_TYPE key_type,
+                                    CK_ULONG expected_size,
+                                    const CK_ATTRIBUTE *attr,
+                                    unsigned char **decoded,
+                                    size_t *decoded_len);
+
+#endif /* _OBJ_EC_POINT_H_ */

--- a/src/obj/fetch.c
+++ b/src/obj/fetch.c
@@ -380,7 +380,7 @@ static CK_RV pre_process_ec_key_data(P11PROV_OBJ *key)
         return CKR_OK;
     }
 
-    ret = decode_ec_point(key->ctx, type, attr, &ec_point);
+    ret = decode_ec_point(key->ctx, type, key->data.key.size, attr, &ec_point);
     if (ret != CKR_OK) {
         return ret;
     }

--- a/src/obj/internal.h
+++ b/src/obj/internal.h
@@ -58,7 +58,8 @@ P11PROV_OBJ *p11prov_obj_pool_find(P11PROV_OBJ_POOL *pool,
                                    CK_ULONG param_set, CK_ULONG bit_size,
                                    CK_ATTRIBUTE *attrs, int numattrs);
 CK_RV decode_ec_point(P11PROV_CTX *provctx, CK_KEY_TYPE key_type,
-                      CK_ATTRIBUTE *attr, struct data_buffer *ec_point);
+                      CK_ULONG expected_size, CK_ATTRIBUTE *attr,
+                      struct data_buffer *ec_point);
 CK_RV get_attrs_from_cert(P11PROV_OBJ *crt, CK_ATTRIBUTE *attrs, int num);
 CK_RV p11prov_match_curve(CK_KEY_TYPE type, CK_ATTRIBUTE *attr,
                           const char **curve_name, int *curve_nid,

--- a/src/obj/keymgmt.c
+++ b/src/obj/keymgmt.c
@@ -2,6 +2,7 @@
    SPDX-License-Identifier: Apache-2.0 */
 
 #include "obj/internal.h"
+#include "obj/ec_point.h"
 #include "kmgmt/keymgmt.h"
 
 bool p11prov_obj_is_rsa_pss(P11PROV_OBJ *obj)
@@ -292,12 +293,10 @@ done:
 }
 
 CK_RV decode_ec_point(P11PROV_CTX *provctx, CK_KEY_TYPE key_type,
-                      CK_ATTRIBUTE *attr, struct data_buffer *ec_point)
+                      CK_ULONG expected_size, CK_ATTRIBUTE *attr,
+                      struct data_buffer *ec_point)
 {
-    ASN1_OCTET_STRING *octet;
-    const unsigned char *val;
-    CK_RV ret = CKR_GENERAL_ERROR;
-    int err;
+    CK_RV ret;
 
     /* Some of the ASN.1 operation may leave errors on the stack
      * which cause TLS operation to fail even if they are benign
@@ -305,54 +304,14 @@ CK_RV decode_ec_point(P11PROV_CTX *provctx, CK_KEY_TYPE key_type,
      * stack if we want to ignore an error */
     p11prov_set_error_mark(provctx);
 
-    /* in d2i functions 'in' is overwritten to return the remainder of
-     * the buffer after parsing, so we always need to avoid passing in
-     * our pointer holders, to avoid having them clobbered */
-    val = attr->pValue;
-    octet = d2i_ASN1_OCTET_STRING(NULL, (const unsigned char **)&val,
-                                  attr->ulValueLen);
-    if (!octet) {
-        /* 3.1 spec says CKA_EC_POINT is not DER encoded for Edwards and
-         * Montgomery curves so do not fail in that case and just take
-         * the value as is */
-        if (key_type == CKK_EC) {
-            ret = CKR_KEY_INDIGESTIBLE;
-            goto done;
-        } else {
-            octet = ASN1_OCTET_STRING_new();
-            if (!octet) {
-                ret = CKR_HOST_MEMORY;
-                goto done;
-            }
-            /* makes a copy of the value */
-            err = ASN1_OCTET_STRING_set(octet, attr->pValue, attr->ulValueLen);
-            if (err != RET_OSSL_OK) {
-                ret = CKR_HOST_MEMORY;
-                goto done;
-            }
-        }
-    }
-
-    ec_point->data =
-        OPENSSL_memdup(ASN1_STRING_get0_data(octet), ASN1_STRING_length(octet));
-    if (!ec_point->data) {
-        ret = CKR_HOST_MEMORY;
-        ec_point->length = 0;
-        goto done;
-    }
-    ec_point->length = ASN1_STRING_length(octet);
-
-    ret = CKR_OK;
-done:
+    ret = p11prov_decode_ec_point_value(key_type, expected_size, attr,
+                                        &ec_point->data, &ec_point->length);
     if (ret == CKR_OK) {
         /* we want to ignore decoding errors in this case */
         p11prov_pop_error_to_mark(provctx);
     } else {
         /* we want to leave errors in this case */
         p11prov_clear_last_error_mark(provctx);
-    }
-    if (octet) {
-        ASN1_OCTET_STRING_free(octet);
     }
     return ret;
 }
@@ -377,8 +336,8 @@ CK_ATTRIBUTE *p11prov_obj_get_ec_public_raw(P11PROV_OBJ *key)
             void *tmp_ptr;
             CK_RV ret;
 
-            ret =
-                decode_ec_point(key->ctx, key->data.key.type, ec_point, &data);
+            ret = decode_ec_point(key->ctx, key->data.key.type,
+                                  key->data.key.size, ec_point, &data);
             if (ret != CKR_OK) {
                 P11PROV_raise(key->ctx, ret, "Failed to decode EC_POINT");
                 return NULL;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -123,8 +123,21 @@ foreach t, sources : test_programs
   test_executables += [t]
 endforeach
 
+ec_point_test = executable(
+  'tecpoint',
+  ['tecpoint.c', '../src/obj/ec_point.c'],
+  build_by_default: false,
+  include_directories: [configinc, include_directories('../src')],
+  dependencies: [libcrypto],
+)
+
 setup_script=find_program('setup.sh')
 all_suites=['softokn', 'softhsm', 'kryoptic', 'kryoptic.nss']
+test(
+  'ec-point-decode',
+  ec_point_test,
+  suite: ['unittests'] + all_suites,
+)
 foreach suite : all_suites + ['kryoptic.multislot']
   test(
     'setup',

--- a/tests/tecpoint.c
+++ b/tests/tecpoint.c
@@ -1,0 +1,116 @@
+/* Copyright (C) 2026 Mounir IDRASSI
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/crypto.h>
+
+#include "../src/obj/ec_point.h"
+
+static int failures;
+
+static void expect_success(const char *name, CK_KEY_TYPE key_type,
+                           CK_ULONG expected_size, const unsigned char *input,
+                           size_t input_len, const unsigned char *expected,
+                           size_t expected_len)
+{
+    CK_ATTRIBUTE attr = { CKA_EC_POINT, (void *)input, input_len };
+    unsigned char *decoded = NULL;
+    size_t decoded_len = 0;
+    CK_RV ret;
+
+    ret = p11prov_decode_ec_point_value(key_type, expected_size, &attr,
+                                        &decoded, &decoded_len);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "%s: decode failed with 0x%lx\n", name, ret);
+        failures++;
+        return;
+    }
+    if (decoded_len != expected_len
+        || memcmp(decoded, expected, expected_len) != 0) {
+        fprintf(stderr, "%s: decoded value does not match\n", name);
+        failures++;
+    }
+    OPENSSL_free(decoded);
+}
+
+static void expect_failure(const char *name, CK_KEY_TYPE key_type,
+                           CK_ULONG expected_size, const unsigned char *input,
+                           size_t input_len, CK_RV expected_ret)
+{
+    CK_ATTRIBUTE attr = { CKA_EC_POINT, (void *)input, input_len };
+    unsigned char *decoded = NULL;
+    size_t decoded_len = 0;
+    CK_RV ret;
+
+    ret = p11prov_decode_ec_point_value(key_type, expected_size, &attr,
+                                        &decoded, &decoded_len);
+    if (ret != expected_ret || decoded != NULL || decoded_len != 0) {
+        fprintf(stderr, "%s: got 0x%lx, expected 0x%lx\n", name, ret,
+                expected_ret);
+        failures++;
+    }
+    OPENSSL_free(decoded);
+}
+
+int main(void)
+{
+    /* Public keys generated from deterministic private-key test vectors. */
+    const unsigned char raw_x25519[] = {
+        0x04, 0x1e, 0xf8, 0x1d, 0x4b, 0xf2, 0x30, 0xd8, 0xa8, 0x31, 0x9a,
+        0x07, 0x50, 0x62, 0xbb, 0xeb, 0x66, 0x6b, 0xe7, 0x3c, 0x7c, 0xac,
+        0x92, 0x05, 0x43, 0xd8, 0x58, 0x01, 0x95, 0xa9, 0xa6, 0x35,
+    };
+    const unsigned char raw_ed25519[] = {
+        0x04, 0x1e, 0x8c, 0xf3, 0xd8, 0xe3, 0x29, 0xb7, 0xed, 0x76, 0x6f,
+        0x98, 0x7e, 0x64, 0x5e, 0x49, 0xb5, 0xf7, 0xdc, 0x8e, 0x3f, 0xb6,
+        0x60, 0x63, 0xe7, 0xd3, 0xfd, 0x57, 0x97, 0xaa, 0xb1, 0x07,
+    };
+    unsigned char der_wrapped[34];
+    unsigned char der_trailing[35];
+    unsigned char der_short[33];
+    const unsigned char traditional_der[] = { 0x04, 0x03, 0x04, 0x01, 0x02 };
+    const unsigned char traditional_point[] = { 0x04, 0x01, 0x02 };
+    const unsigned char traditional_raw[] = { 0x05, 0x01, 0x02 };
+
+    /* Each raw key is also a complete 30-byte DER OCTET STRING. */
+    expect_success("raw X25519 DER collision", CKK_EC_MONTGOMERY,
+                   sizeof(raw_x25519), raw_x25519, sizeof(raw_x25519),
+                   raw_x25519, sizeof(raw_x25519));
+    expect_success("raw Ed25519 DER collision", CKK_EC_EDWARDS,
+                   sizeof(raw_ed25519), raw_ed25519, sizeof(raw_ed25519),
+                   raw_ed25519, sizeof(raw_ed25519));
+
+    der_wrapped[0] = 0x04;
+    der_wrapped[1] = sizeof(raw_x25519);
+    memcpy(&der_wrapped[2], raw_x25519, sizeof(raw_x25519));
+    expect_success("DER OCTET STRING-wrapped X25519", CKK_EC_MONTGOMERY,
+                   sizeof(raw_x25519), der_wrapped, sizeof(der_wrapped),
+                   raw_x25519, sizeof(raw_x25519));
+
+    memcpy(der_trailing, der_wrapped, sizeof(der_wrapped));
+    der_trailing[sizeof(der_trailing) - 1] = 0;
+    expect_failure("DER with trailing data", CKK_EC_MONTGOMERY,
+                   sizeof(raw_x25519), der_trailing, sizeof(der_trailing),
+                   CKR_KEY_INDIGESTIBLE);
+
+    der_short[0] = 0x04;
+    der_short[1] = sizeof(raw_x25519) - 1;
+    memcpy(&der_short[2], raw_x25519, sizeof(raw_x25519) - 1);
+    expect_failure("DER with short point", CKK_EC_MONTGOMERY,
+                   sizeof(raw_x25519), der_short, sizeof(der_short),
+                   CKR_KEY_INDIGESTIBLE);
+
+    expect_failure("unsupported key type", CKK_RSA, sizeof(raw_x25519),
+                   raw_x25519, sizeof(raw_x25519), CKR_KEY_TYPE_INCONSISTENT);
+
+    expect_success("traditional EC DER", CKK_EC, sizeof(traditional_point),
+                   traditional_der, sizeof(traditional_der), traditional_point,
+                   sizeof(traditional_point));
+    expect_failure("traditional EC raw", CKK_EC, sizeof(traditional_raw),
+                   traditional_raw, sizeof(traditional_raw),
+                   CKR_KEY_INDIGESTIBLE);
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #766.

#483, addressing #478, added support for raw `CKA_EC_POINT` values alongside the existing DER OCTET STRING decoding. The decoder currently tries the DER form first and uses raw bytes only when that fails. That order is ambiguous because an arbitrary raw Edwards or Montgomery public key can start with a valid DER OCTET STRING header.

For example, a 32-byte raw X25519 value beginning with `04 1e` is accepted as a DER OCTET STRING containing only 30 bytes. The truncated value can later be exported as a TLS key share and cause an intermittent `bad key share` failure.

Make EC point decoding curve-length-aware:

- Treat an Edwards or Montgomery `CKA_EC_POINT` whose length matches the selected curve as raw, without probing it as ASN.1.
- Continue accepting legacy DER OCTET STRING-wrapped ECX points, but require the decoder to consume the complete attribute and require the decoded point to have the expected curve size.
- Leave existing traditional `CKK_EC` point decoding behavior unchanged.
- Keep the ASN.1 error-stack handling around the decoder so rejected probes don't contaminate later OpenSSL operations.

The decoding logic is isolated in a small internal helper so it can be tested without relying on randomized token key generation. The regression test uses deterministically generated 32-byte `04 1e ...` values and verifies raw X25519 and Ed25519 handling, legacy DER OCTET STRING compatibility, rejection of trailing and wrong-length wrapped values, and traditional EC behavior.

#### Testing

- Built the provider and unit test against OpenSSL 3.0.13.
- Built the provider and unit test against OpenSSL 4.1.0-dev.
- Ran the token-independent `ec-point-decode` unit-test instance under the `softokn`, `softhsm`, `kryoptic`, and `kryoptic.nss` Meson suite labels against both OpenSSL versions.
- Ran all four suite-tagged unit-test instances under Valgrind against both OpenSSL versions.
- Ran `make check-style` and `clang-format --dry-run --Werror` on the new sources.

#### Checklist

- [x] Code modified for bug fix
- [x] Test suite updated with functionality tests
- [x] Test suite updated with negative tests

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
