### PR TITLE
Detect mechanism support and pkcs11-tool support for key generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,3 @@
----
 name: Build
 
 on:
@@ -119,6 +118,14 @@ jobs:
             # The Meson in Ubuntu 24 has a bug that it can not correctly detect
             # the clangs, gcovr and crashes. Skip it for now.
             echo "skipcoverage=true" >> $GITHUB_OUTPUT
+          fi
+          if [ "${{ matrix.token }}" = "softokn" ]; then
+            NSSMINVER=`nss-config --version nss | cut -d '.' -f 2`
+            if [ $NSSMINVER -lt 125 ]; then
+              # Some older version of NSS claim ML-KEM support but can't store
+              # ML-KEM keys on the token
+              echo "SUPPRESS_ML_KEM=1" >> $GITHUB_ENV
+            fi
           fi
 
       - name: Checkout Repository

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -140,3 +140,28 @@ check_mechanism() {
     fi
     echo "${P11MECHS}" | grep -q -E "^\s*${mech}(,|\s|$)"
 }
+
+check_algorithm_support() {
+    local alg="$1"
+    local op_mech1="$2"
+    local op_mech2="$3"
+    local kg_mech1="$4"
+    local kg_mech2="$5"
+
+    local suppress_var="SUPPRESS_${alg}"
+    local support_var="SUPPORT_${alg}"
+    local support_kg_var="SUPPORT_${alg}_KEY_GEN"
+
+    if [ "${!suppress_var}" -ne 1 ]; then
+        if check_mechanism "${op_mech1}" || check_mechanism "${op_mech2}"; then
+            eval "${support_var}=1"
+            if check_mechanism "${kg_mech1}"; then
+                eval "${support_kg_var}=1"
+            elif check_mechanism "${kg_mech2}"; then
+                eval "${support_kg_var}=2"
+            else
+                eval "${support_var}=0"
+            fi
+        fi
+    fi
+}

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -132,3 +132,11 @@ ptool() {
     export OPENSSL_CONF=${ORIG_OPENSSL_CONF}
     export LD_PRELOAD=${ORIG_LD_PRELOAD}
 }
+
+check_mechanism() {
+    local mech="$1"
+    if [ -z "${P11MECHS}" ]; then
+        P11MECHS=$(ptool -M 2>/dev/null || true)
+    fi
+    echo "${P11MECHS}" | grep -q -E "^\s*${mech}(,|\s|$)"
+}

--- a/tests/kryoptic-init.sh
+++ b/tests/kryoptic-init.sh
@@ -54,19 +54,6 @@ export TESTPORT="34000"
 
 export SUPPORT_ALLOWED_MECHANISMS=1
 
-# Enable SUPPORT_ML_DSA as long as it is not set already.
-if [ -z "$SUPPORT_ML_DSA" ]; then
-    export SUPPORT_ML_DSA=1
-fi
-# Enable SUPPORT_ML_KEM as long as it is not set already.
-if [ -z "$SUPPORT_ML_KEM" ]; then
-    export SUPPORT_ML_KEM=1
-fi
-# Enable SUPPORT_SLH_DSA as long as it is not set already.
-if [ -z "$SUPPORT_SLH_DSA" ]; then
-    export SUPPORT_SLH_DSA=1
-fi
-
 # In theory Kryoptic could be statically linked to a version of OpenSSL that
 # does support serializing contexts, even though the system as whole does
 # not. In that case op_state test will "unexpectedly" succeed, and will need

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -21,11 +21,11 @@ fi
 TOKENTYPE=$1
 
 # defaults -- overridden below or in the per-token setup
-SUPPORT_ED25519=1
-SUPPORT_ED448=1
+SUPPORT_ED25519=0
+SUPPORT_ED448=0
 SUPPORT_EDDSA_PARAMS=1
-SUPPORT_X25519=1
-SUPPORT_X448=1
+SUPPORT_X25519=0
+SUPPORT_X448=0
 SUPPORT_RSA_PKCS1_ENCRYPTION=1
 SUPPORT_RSA_KEYGEN_PUBLIC_EXPONENT=1
 SUPPORT_TLSFUZZER=1
@@ -33,21 +33,40 @@ SUPPORT_ALLOWED_MECHANISMS=0
 SUPPORT_SYMMETRIC=1
 SUPPORT_BLOCK_MODES="CBC OFB CFB CFB1 CFB8 CTR ECB"
 SUPPORT_OPERATION_STATE=0
+SUPPORT_ML_DSA=0
+SUPPORT_ML_KEM=0
+SUPPORT_SLH_DSA=0
+SUPPORT_ED25519_KEY_GEN=0
+SUPPORT_ED448_KEY_GEN=0
+SUPPORT_X25519_KEY_GEN=0
+SUPPORT_X448_KEY_GEN=0
+SUPPORT_ML_DSA_KEY_GEN=0
+SUPPORT_ML_KEM_KEY_GEN=0
+SUPPORT_SLH_DSA_KEY_GEN=0
+SUPPRESS_ED25519=${SUPPRESS_ED25519:-0}
+SUPPRESS_ED448=${SUPPRESS_ED448:-0}
+SUPPRESS_X25519=${SUPPRESS_X25519:-0}
+SUPPRESS_X448=${SUPPRESS_X448:-0}
+SUPPRESS_ML_DSA=${SUPPRESS_ML_DSA:-0}
+SUPPRESS_ML_KEM=${SUPPRESS_ML_KEM:-0}
+SUPPRESS_SLH_DSA=${SUPPRESS_SLH_DSA:-0}
 
 # Ed448 requires OpenSC 0.26.0
 OPENSC_VERSION=$(opensc-tool -i | grep OpenSC | sed -e "s/OpenSC 0\.\([0-9]*\).*/\1/")
 if [[ "$OPENSC_VERSION" -le "25" ]]; then
-    SUPPORT_ED448=0
+    SUPPRESS_ED448=1
 fi
 
 # FIPS Mode
 if [[ "${PKCS11_PROVIDER_FORCE_FIPS_MODE}" = "1" || "$(cat /proc/sys/crypto/fips_enabled)" = "1" ]]; then
-    # We can not use Edwards curves in FIPS mode
-    SUPPORT_ED25519=0
-    SUPPORT_ED448=0
-    # We can not use Montgomery curves in FIPS mode
-    SUPPORT_X25519=0
-    SUPPORT_X448=0
+    # We can not use any of these algorithms in FIPS mode .. yet
+    SUPPRESS_ED25519=1
+    SUPPRESS_ED448=1
+    SUPPRESS_X25519=1
+    SUPPRESS_X448=1
+    SUPPRESS_ML_DSA=1
+    SUPPRESS_ML_KEM=1
+    SUPPRESS_SLH_DSA=1
 
     # The FIPS does not allow the RSA-PKCS1.5 encryption
     SUPPORT_RSA_PKCS1_ENCRYPTION=0
@@ -106,6 +125,91 @@ else
     exit 1
 fi
 
+if [ "${SUPPRESS_ED25519}" -ne 1 ]; then
+    if check_mechanism "EDDSA" || check_mechanism "mechtype-0x1057"; then
+        SUPPORT_ED25519=1
+        if check_mechanism "EC-EDWARDS-KEY-PAIR-GEN"; then
+            SUPPORT_ED25519_KEY_GEN=1
+        elif check_mechanism "mechtype-0x1055"; then
+            SUPPORT_ED25519_KEY_GEN=2
+        else
+            SUPPORT_ED25519=0
+        fi
+    fi
+fi
+if [ "${SUPPRESS_ED448}" -ne 1 ]; then
+    if check_mechanism "EDDSA" || check_mechanism "mechtype-0x1057"; then
+        SUPPORT_ED448=1
+        if check_mechanism "EC-EDWARDS-KEY-PAIR-GEN"; then
+            SUPPORT_ED448_KEY_GEN=1
+        elif check_mechanism "mechtype-0x1055"; then
+            SUPPORT_ED448_KEY_GEN=2
+        else
+            SUPPORT_ED448=0
+        fi
+    fi
+fi
+if [ "${SUPPRESS_X25519}" -ne 1 ]; then
+    if check_mechanism "ECDH1-DERIVE" || check_mechanism "mechtype-0x1050"; then
+        SUPPORT_X25519=1
+        if check_mechanism "EC-MONTGOMERY-KEY-PAIR-GEN"; then
+            SUPPORT_X25519_KEY_GEN=1
+        elif check_mechanism "mechtype-0x1050"; then
+            SUPPORT_X25519_KEY_GEN=2
+        else
+            SUPPORT_X25519=0
+        fi
+    fi
+fi
+if [ "${SUPPRESS_X448}" -ne 1 ]; then
+    if check_mechanism "ECDH1-DERIVE" || check_mechanism "mechtype-0x1050"; then
+        SUPPORT_X448=1
+        if check_mechanism "EC-MONTGOMERY-KEY-PAIR-GEN"; then
+            SUPPORT_X448_KEY_GEN=1
+        elif check_mechanism "mechtype-0x1050"; then
+            SUPPORT_X448_KEY_GEN=2
+        else
+            SUPPORT_X448=0
+        fi
+    fi
+fi
+if [ "${SUPPRESS_ML_DSA}" -ne 1 ]; then
+    if check_mechanism "ML-DSA" || check_mechanism "mechtype-0x1D"; then
+        SUPPORT_ML_DSA=1
+        if check_mechanism "ML-DSA-KEY-PAIR-GEN"; then
+            SUPPORT_ML_DSA_KEY_GEN=1
+        elif check_mechanism "mechtype-0x1C"; then
+            SUPPORT_ML_DSA_KEY_GEN=2
+        else
+            SUPPORT_ML_DSA=0
+        fi
+    fi
+fi
+if [ "${SUPPRESS_ML_KEM}" -ne 1 ]; then
+    if check_mechanism "ML-KEM" || check_mechanism "mechtype-0x17"; then
+        SUPPORT_ML_KEM=1
+        if check_mechanism "ML-KEM-KEY-PAIR-GEN"; then
+            SUPPORT_ML_KEM_KEY_GEN=1
+        elif check_mechanism "mechtype-0xF"; then
+            SUPPORT_ML_KEM_KEY_GEN=2
+        else
+            SUPPORT_ML_KEM=0
+        fi
+    fi
+fi
+if [ "${SUPPRESS_SLH_DSA}" -ne 1 ]; then
+    if ! check_mechanism "SLH-DSA" || check_mechanism "mechtype-0x2E"; then
+        SUPPORT_SLH_DSA=1
+        if check_mechanism "SLH-DSA-KEY-PAIR-GEN"; then
+            SUPPORT_SLH_DSA_KEY_GEN=1
+        elif check_mechanism "mechtype-0x2D"; then
+            SUPPORT_SLH_DSA_KEY_GEN=2
+        else
+            SUPPORT_SLH_DSA=0
+        fi
+    fi
+fi
+
 if [[ "${PKCS11_PROVIDER_FORCE_FIPS_MODE}" = "1" ]]; then
     # temporarily suppress symmetric tests in FIPS mode as no FIPS provider
     # supports SKEYMGMT yet.
@@ -139,6 +243,12 @@ sed -e "s|@libtoollibs@|${LIBSPATH}|g" \
     -e "s|@PINFILE@|${PINFILE}|g" \
     -e "s|##TOKENOPTIONS|${TOKENOPTIONS}|g" \
     "${TESTSSRCDIR}/openssl.cnf.in" > "${OPENSSL_CONF}"
+BASE_OPENSSL_CONF=$OPENSSL_CONF
+
+# prepare also a config version that enables uri-to-pem
+sed -e "s/#pkcs11-module-encode-provider-uri-to-pem/pkcs11-module-encode-provider-uri-to-pem = true/" \
+    "${OPENSSL_CONF}" > "${OPENSSL_CONF}.uri_to_pem"
+URIPEM_OPENSSL_CONF=${OPENSSL_CONF}.uri_to_pem
 
 # setup configuration that forces all operations on token here
 BLOCKED_OPERATIONS="digest"
@@ -305,13 +415,25 @@ echo ""
 
 
 ## Softtokn does not support edwards curves yet
-if [ "${SUPPORT_ED25519}" -eq 1 ]; then
+if [ "$SUPPORT_ED25519_KEY_GEN" -ne 0 ]; then
     # generate ED25519
     get_next_keyid
     EDCRTN="edCert"
 
-    ptool --keypairgen --key-type="EC:edwards25519" --id="$KEYID" \
-    	  --label="${EDCRTN}" 2>&1
+    if [ "$SUPPORT_ED25519_KEY_GEN" -eq 1 ]; then
+        ptool --keypairgen --key-type="EC:edwards25519" --id="$KEYID" \
+            --label="${EDCRTN}" 2>&1
+    elif [ "$SUPPORT_ED25519_KEY_GEN" -eq 2 ]; then
+        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
+        ossl '
+        genpkey -propquery "provider=pkcs11"
+                -algorithm ED25519
+                -pkeyopt "pkcs11_uri:pkcs11:object=${EDCRTN};id=${URIKEYID}"'
+        OPENSSL_CONF=${BASE_OPENSSL_CONF}
+    else
+        echo "Bad value for SUPPORT_ED25519_KEY_GEN: $SUPPORT_ED25519_KEY_GEN"
+        exit 1
+    fi
     ca_sign $EDCRTN "My ED25519 Cert" "$KEYID"
 
     EDBASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
@@ -330,13 +452,25 @@ if [ "${SUPPORT_ED25519}" -eq 1 ]; then
     echo "${EDCRTURI}"
 fi
 
-if [ "${SUPPORT_ED448}" -eq 1 ]; then
+if [ "$SUPPORT_ED448_KEY_GEN" -ne 0 ]; then
     # generate ED448
     get_next_keyid
     ED2CRTN="ed2Cert"
 
-    ptool --keypairgen --key-type="EC:Ed448" --id="$KEYID" \
-          --label="${ED2CRTN}" 2>&1
+    if [ "$SUPPORT_ED448_KEY_GEN" -eq 1 ]; then
+        ptool --keypairgen --key-type="EC:Ed448" --id="$KEYID" \
+            --label="${ED2CRTN}" 2>&1
+    elif [ "$SUPPORT_ED448_KEY_GEN" -eq 2 ]; then
+        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
+        ossl '
+        genpkey -propquery "provider=pkcs11"
+                -algorithm ED448
+                -pkeyopt "pkcs11_uri:pkcs11:object=${ED2CRTN};id=${URIKEYID}"'
+        OPENSSL_CONF=${BASE_OPENSSL_CONF}
+    else
+        echo "Bad value for SUPPORT_ED448_KEY_GEN: $SUPPORT_ED448_KEY_GEN"
+        exit 1
+    fi
     ca_sign $ED2CRTN "My ED448 Cert" "$KEYID"
 
     ED2BASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
@@ -355,12 +489,25 @@ if [ "${SUPPORT_ED448}" -eq 1 ]; then
     echo "${ED2CRTURI}"
 fi
 
-if [ "${SUPPORT_X25519}" -eq 1 ]; then
+if [ "$SUPPORT_X25519_KEY_GEN" -ne 0 ]; then
     # generate X25519
     get_next_keyid
+    TSTCRTN="x25519 key"
 
-    ptool --keypairgen --key-type="EC:X25519" --id="$KEYID" \
-    	  --label="x25519 key" 2>&1
+    if [ "$SUPPORT_X25519_KEY_GEN" -eq 1 ]; then
+        ptool --keypairgen --key-type="EC:X25519" --id="$KEYID" \
+            --label="${TSTCRTN}" 2>&1
+    elif [ "$SUPPORT_X25519_KEY_GEN" -eq 2 ]; then
+        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
+        ossl '
+        genpkey -propquery "provider=pkcs11"
+                -algorithm X25519
+                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
+        OPENSSL_CONF=${BASE_OPENSSL_CONF}
+    else
+        echo "Bad value for SUPPORT_X25519_KEY_GEN: $SUPPORT_X25519_KEY_GEN"
+        exit 1
+    fi
 
     X25519BASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
     X25519BASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID};pin-source=file:${PINFILE}"
@@ -377,9 +524,19 @@ if [ "${SUPPORT_X25519}" -eq 1 ]; then
 
     # And a Peer Key for Key Exchange (ECDH) tests
     get_next_keyid
+    TSTCRTN="x25519 key"
 
-    ptool --keypairgen --key-type="EC:X25519" --id="$KEYID" \
-    	  --label="x25519 key" 2>&1
+    if [ "$SUPPORT_X25519_KEY_GEN" -eq 1 ]; then
+        ptool --keypairgen --key-type="EC:X25519" --id="$KEYID" \
+            --label="${TSTCRTN}" 2>&1
+    elif [ "$SUPPORT_X25519_KEY_GEN" -eq 2 ]; then
+        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
+        ossl '
+        genpkey -propquery "provider=pkcs11"
+                -algorithm X25519
+                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
+        OPENSSL_CONF=${BASE_OPENSSL_CONF}
+    fi
 
     X25519PEERPUBURI="pkcs11:type=public;id=${URIKEYID}"
     X25519PEERPRIURI="pkcs11:type=private;id=${URIKEYID}"
@@ -389,12 +546,25 @@ if [ "${SUPPORT_X25519}" -eq 1 ]; then
     echo "${X25519PEERPRIURI}"
 fi
 
-if [ "${SUPPORT_X448}" -eq 1 ]; then
+if [ "$SUPPORT_X448_KEY_GEN" -ne 0 ]; then
     # generate X448
     get_next_keyid
+    TSTCRTN="x448 key"
 
-    ptool --keypairgen --key-type="EC:X448" --id="$KEYID" \
-    	  --label="x448 key" 2>&1
+    if [ "$SUPPORT_X448_KEY_GEN" -eq 1 ]; then
+        ptool --keypairgen --key-type="EC:X448" --id="$KEYID" \
+            --label="${TSTCRTN}" 2>&1
+    elif [ "$SUPPORT_X448_KEY_GEN" -eq 2 ]; then
+        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
+        ossl '
+        genpkey -propquery "provider=pkcs11"
+                -algorithm X448
+                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
+        OPENSSL_CONF=${BASE_OPENSSL_CONF}
+    else
+        echo "Bad value for SUPPORT_X448_KEY_GEN: $SUPPORT_X448_KEY_GEN"
+        exit 1
+    fi
 
     X448BASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
     X448BASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID};pin-source=file:${PINFILE}"
@@ -411,9 +581,19 @@ if [ "${SUPPORT_X448}" -eq 1 ]; then
 
     # And a Peer Key for Key Exchange (ECDH) tests
     get_next_keyid
+    TSTCRTN="x448 key"
 
-    ptool --keypairgen --key-type="EC:X448" --id="$KEYID" \
-    	  --label="x448 key" 2>&1
+    if [ "$SUPPORT_X448_KEY_GEN" -eq 1 ]; then
+        ptool --keypairgen --key-type="EC:X448" --id="$KEYID" \
+            --label="${TSTCRTN}" 2>&1
+    elif [ "$SUPPORT_X448_KEY_GEN" -eq 2 ]; then
+        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
+        ossl '
+        genpkey -propquery "provider=pkcs11"
+                -algorithm X448
+                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
+        OPENSSL_CONF=${BASE_OPENSSL_CONF}
+    fi
 
     X448PEERPUBURI="pkcs11:type=public;id=${URIKEYID}"
     X448PEERPRIURI="pkcs11:type=private;id=${URIKEYID}"
@@ -575,25 +755,25 @@ if [ "${SUPPORT_ALLOWED_MECHANISMS}" -eq 1 ]; then
     echo ""
 fi
 
-if [ "$SUPPORT_ML_DSA" -eq 1 ]; then
+if [ "$SUPPORT_ML_DSA_KEY_GEN" -ne 0 ]; then
     title PARA "generate ML-DSA Key pair"
     get_next_keyid
     TSTCRTN="mlDsa"
 
-    # not supported by the pkcs11-tool yet. Do it for now with OpenSSL CLI
-    # ptool --keypairgen --key-type="ML-DSA-44" --id="$KEYID" \
-    #       --label="${TSTCRTN}" 2>&1
-    ORIG_OPENSSL_CONF=${OPENSSL_CONF}
-    # We need to configure pkcs11 to allow emitting PEM URIs so that the
-    # genpkey command does not fail on trying to emit the private key PEM file.
-    sed -e "s/#pkcs11-module-encode-provider-uri-to-pem/pkcs11-module-encode-provider-uri-to-pem = true/" \
-        "${OPENSSL_CONF}" > "${OPENSSL_CONF}.mldsa_pem_uri"
-    OPENSSL_CONF=${OPENSSL_CONF}.mldsa_pem_uri
-    ossl '
-    genpkey -propquery "provider=pkcs11"
-            -algorithm ML-DSA-44
-            -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
-    OPENSSL_CONF=${ORIG_OPENSSL_CONF}
+    if [ "$SUPPORT_ML_DSA_KEY_GEN" -eq 1 ]; then
+        ptool --keypairgen --key-type="ML-DSA-44" --id="$KEYID" \
+            --label="${TSTCRTN}" 2>&1
+    elif [ "$SUPPORT_ML_DSA_KEY_GEN" -eq 2 ]; then
+        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
+        ossl '
+        genpkey -propquery "provider=pkcs11"
+                -algorithm ML-DSA-44
+                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
+        OPENSSL_CONF=${BASE_OPENSSL_CONF}
+    else
+        echo "Bad value for SUPPORT_ML_DSA_KEY_GEN: $SUPPORT_ML_DSA_KEY_GEN"
+        exit 1
+    fi
     ca_sign $TSTCRTN "My ML-DSA Cert" "$KEYID"
 
     MLDSABASEURIWITHPINVALUE="pkcs11:id=${URIKEYID}?pin-value=${PINVALUE}"
@@ -611,23 +791,26 @@ if [ "$SUPPORT_ML_DSA" -eq 1 ]; then
     echo ""
 fi
 
-if [ "$SUPPORT_ML_KEM" -eq 1 ]; then
+if [ "$SUPPORT_ML_KEM_KEY_GEN" -ne 0 ]; then
     title PARA "generate ML-KEM Key pair"
     get_next_keyid
     TSTCRTN="mlKem"
 
-    # not supported by the pkcs11-tool yet. Do it for now with OpenSSL CLI
-    ORIG_OPENSSL_CONF=${OPENSSL_CONF}
-    # We need to configure pkcs11 to allow emitting PEM URIs so that the
-    # genpkey command does not fail on trying to emit the private key PEM file.
-    sed -e "s/#pkcs11-module-encode-provider-uri-to-pem/pkcs11-module-encode-provider-uri-to-pem = true/" \
-        "${OPENSSL_CONF}" > "${OPENSSL_CONF}.mlkem_pem_uri"
-    OPENSSL_CONF=${OPENSSL_CONF}.mlkem_pem_uri
-    ossl '
-    genpkey -propquery "provider=pkcs11"
-            -algorithm ML-KEM-512
-            -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
-    OPENSSL_CONF=${ORIG_OPENSSL_CONF}
+    if [ "$SUPPORT_ML_KEM_KEY_GEN" -eq 1 ]; then
+        ptool --keypairgen --key-type="ML-KEM-512" --id="$KEYID" \
+            --label="${TSTCRTN}" 2>&1
+
+    elif [ "$SUPPORT_ML_KEM_KEY_GEN" -eq 2 ]; then
+        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
+        ossl '
+        genpkey -propquery "provider=pkcs11"
+                -algorithm ML-KEM-512
+                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
+        OPENSSL_CONF=${BASE_OPENSSL_CONF}
+    else
+        echo "Bad value for SUPPORT_ML_KEM_KEY_GEN: $SUPPORT_ML_KEM_KEY_GEN"
+        exit 1
+    fi
 
     MLKEMBASEURIWITHPINVALUE="pkcs11:id=${URIKEYID}?pin-value=${PINVALUE}"
     MLKEMBASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID}?pin-source=file:${PINFILE}"
@@ -642,25 +825,25 @@ if [ "$SUPPORT_ML_KEM" -eq 1 ]; then
     echo ""
 fi
 
-if [ "$SUPPORT_SLH_DSA" -eq 1 ]; then
+if [ "$SUPPORT_SLH_DSA_KEY_GEN" -ne 0 ]; then
     title PARA "generate SLH-DSA Key pair"
     get_next_keyid
     TSTCRTN="slhDsa"
 
-    # not supported by the pkcs11-tool yet. Do it for now with OpenSSL CLI
-    # ptool --keypairgen --key-type="SLH-DSA-SHAKE-128S" --id="$KEYID" \
-    #       --label="${TSTCRTN}" 2>&1
-    ORIG_OPENSSL_CONF=${OPENSSL_CONF}
-    # We need to configure pkcs11 to allow emitting PEM URIs so that the
-    # genpkey command does not fail on trying to emit the private key PEM file.
-    sed -e "s/#pkcs11-module-encode-provider-uri-to-pem/pkcs11-module-encode-provider-uri-to-pem = true/" \
-        "${OPENSSL_CONF}" > "${OPENSSL_CONF}.slhdsa_pem_uri"
-    OPENSSL_CONF=${OPENSSL_CONF}.slhdsa_pem_uri
-    ossl '
-    genpkey -propquery "provider=pkcs11"
-            -algorithm SLH-DSA-SHAKE-128s
-            -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
-    OPENSSL_CONF=${ORIG_OPENSSL_CONF}
+    if [ "$SUPPORT_SLH_DSA_KEY_GEN" -eq 1 ]; then
+        ptool --keypairgen --key-type="SLH-DSA-SHAKE-128S" --id="$KEYID" \
+            --label="${TSTCRTN}" 2>&1
+    elif [ "$SUPPORT_SLH_DSA_KEY_GEN" -eq 2 ]; then
+        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
+        ossl '
+        genpkey -propquery "provider=pkcs11"
+                -algorithm SLH-DSA-SHAKE-128s
+                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
+        OPENSSL_CONF=${BASE_OPENSSL_CONF}
+    else
+        echo "Bad value for SUPPORT_SLH_DSA_KEY_GEN: $SUPPORT_SLH_DSA_KEY_GEN"
+        exit 1
+    fi
     ca_sign $TSTCRTN "My SLH-DSA Cert" "$KEYID"
 
     SLHDSABASEURIWITHPINVALUE="pkcs11:id=${URIKEYID}?pin-value=${PINVALUE}"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -208,6 +208,30 @@ crt_selfsign() {
           --label="$LABEL" 2>&1
 }
 
+gen_keypair() {
+    local mode="$1"
+    local ptool_type="$2"
+    local ossl_alg="$3"
+    local label="$4"
+    local id="$5"
+    local uri_id="$6"
+
+    if [ "$mode" -eq 1 ]; then
+        ptool --keypairgen --key-type="${ptool_type}" --id="${id}" \
+            --label="${label}" 2>&1
+    elif [ "$mode" -eq 2 ]; then
+        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
+        ossl "
+        genpkey -propquery \"provider=pkcs11\"
+                -algorithm ${ossl_alg}
+                -pkeyopt \"pkcs11_uri:pkcs11:object=${label};id=${uri_id}\""
+        OPENSSL_CONF=${BASE_OPENSSL_CONF}
+    else
+        echo "Bad value for key gen mode: $mode"
+        exit 1
+    fi
+}
+
 title LINE "Creating new Self Sign CA"
 get_next_keyid
 CACRTN="caCert"
@@ -343,20 +367,8 @@ if [ "$SUPPORT_ED25519_KEY_GEN" -ne 0 ]; then
     get_next_keyid
     EDCRTN="edCert"
 
-    if [ "$SUPPORT_ED25519_KEY_GEN" -eq 1 ]; then
-        ptool --keypairgen --key-type="EC:edwards25519" --id="$KEYID" \
-            --label="${EDCRTN}" 2>&1
-    elif [ "$SUPPORT_ED25519_KEY_GEN" -eq 2 ]; then
-        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
-        ossl '
-        genpkey -propquery "provider=pkcs11"
-                -algorithm ED25519
-                -pkeyopt "pkcs11_uri:pkcs11:object=${EDCRTN};id=${URIKEYID}"'
-        OPENSSL_CONF=${BASE_OPENSSL_CONF}
-    else
-        echo "Bad value for SUPPORT_ED25519_KEY_GEN: $SUPPORT_ED25519_KEY_GEN"
-        exit 1
-    fi
+    gen_keypair "$SUPPORT_ED25519_KEY_GEN" "EC:edwards25519" "ED25519" \
+                "${EDCRTN}" "${KEYID}" "${URIKEYID}"
     ca_sign $EDCRTN "My ED25519 Cert" "$KEYID"
 
     EDBASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
@@ -380,20 +392,8 @@ if [ "$SUPPORT_ED448_KEY_GEN" -ne 0 ]; then
     get_next_keyid
     ED2CRTN="ed2Cert"
 
-    if [ "$SUPPORT_ED448_KEY_GEN" -eq 1 ]; then
-        ptool --keypairgen --key-type="EC:Ed448" --id="$KEYID" \
-            --label="${ED2CRTN}" 2>&1
-    elif [ "$SUPPORT_ED448_KEY_GEN" -eq 2 ]; then
-        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
-        ossl '
-        genpkey -propquery "provider=pkcs11"
-                -algorithm ED448
-                -pkeyopt "pkcs11_uri:pkcs11:object=${ED2CRTN};id=${URIKEYID}"'
-        OPENSSL_CONF=${BASE_OPENSSL_CONF}
-    else
-        echo "Bad value for SUPPORT_ED448_KEY_GEN: $SUPPORT_ED448_KEY_GEN"
-        exit 1
-    fi
+    gen_keypair "$SUPPORT_ED448_KEY_GEN" "EC:Ed448" "ED448" \
+                "${ED2CRTN}" "${KEYID}" "${URIKEYID}"
     ca_sign $ED2CRTN "My ED448 Cert" "$KEYID"
 
     ED2BASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
@@ -417,20 +417,8 @@ if [ "$SUPPORT_X25519_KEY_GEN" -ne 0 ]; then
     get_next_keyid
     TSTCRTN="x25519 key"
 
-    if [ "$SUPPORT_X25519_KEY_GEN" -eq 1 ]; then
-        ptool --keypairgen --key-type="EC:X25519" --id="$KEYID" \
-            --label="${TSTCRTN}" 2>&1
-    elif [ "$SUPPORT_X25519_KEY_GEN" -eq 2 ]; then
-        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
-        ossl '
-        genpkey -propquery "provider=pkcs11"
-                -algorithm X25519
-                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
-        OPENSSL_CONF=${BASE_OPENSSL_CONF}
-    else
-        echo "Bad value for SUPPORT_X25519_KEY_GEN: $SUPPORT_X25519_KEY_GEN"
-        exit 1
-    fi
+    gen_keypair "$SUPPORT_X25519_KEY_GEN" "EC:X25519" "X25519" \
+                "${TSTCRTN}" "${KEYID}" "${URIKEYID}"
 
     X25519BASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
     X25519BASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID};pin-source=file:${PINFILE}"
@@ -449,17 +437,8 @@ if [ "$SUPPORT_X25519_KEY_GEN" -ne 0 ]; then
     get_next_keyid
     TSTCRTN="x25519 key"
 
-    if [ "$SUPPORT_X25519_KEY_GEN" -eq 1 ]; then
-        ptool --keypairgen --key-type="EC:X25519" --id="$KEYID" \
-            --label="${TSTCRTN}" 2>&1
-    elif [ "$SUPPORT_X25519_KEY_GEN" -eq 2 ]; then
-        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
-        ossl '
-        genpkey -propquery "provider=pkcs11"
-                -algorithm X25519
-                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
-        OPENSSL_CONF=${BASE_OPENSSL_CONF}
-    fi
+    gen_keypair "$SUPPORT_X25519_KEY_GEN" "EC:X25519" "X25519" \
+                "${TSTCRTN}" "${KEYID}" "${URIKEYID}"
 
     X25519PEERPUBURI="pkcs11:type=public;id=${URIKEYID}"
     X25519PEERPRIURI="pkcs11:type=private;id=${URIKEYID}"
@@ -474,20 +453,8 @@ if [ "$SUPPORT_X448_KEY_GEN" -ne 0 ]; then
     get_next_keyid
     TSTCRTN="x448 key"
 
-    if [ "$SUPPORT_X448_KEY_GEN" -eq 1 ]; then
-        ptool --keypairgen --key-type="EC:X448" --id="$KEYID" \
-            --label="${TSTCRTN}" 2>&1
-    elif [ "$SUPPORT_X448_KEY_GEN" -eq 2 ]; then
-        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
-        ossl '
-        genpkey -propquery "provider=pkcs11"
-                -algorithm X448
-                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
-        OPENSSL_CONF=${BASE_OPENSSL_CONF}
-    else
-        echo "Bad value for SUPPORT_X448_KEY_GEN: $SUPPORT_X448_KEY_GEN"
-        exit 1
-    fi
+    gen_keypair "$SUPPORT_X448_KEY_GEN" "EC:X448" "X448" \
+                "${TSTCRTN}" "${KEYID}" "${URIKEYID}"
 
     X448BASEURIWITHPINVALUE="pkcs11:id=${URIKEYID};pin-value=${PINVALUE}"
     X448BASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID};pin-source=file:${PINFILE}"
@@ -506,17 +473,8 @@ if [ "$SUPPORT_X448_KEY_GEN" -ne 0 ]; then
     get_next_keyid
     TSTCRTN="x448 key"
 
-    if [ "$SUPPORT_X448_KEY_GEN" -eq 1 ]; then
-        ptool --keypairgen --key-type="EC:X448" --id="$KEYID" \
-            --label="${TSTCRTN}" 2>&1
-    elif [ "$SUPPORT_X448_KEY_GEN" -eq 2 ]; then
-        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
-        ossl '
-        genpkey -propquery "provider=pkcs11"
-                -algorithm X448
-                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
-        OPENSSL_CONF=${BASE_OPENSSL_CONF}
-    fi
+    gen_keypair "$SUPPORT_X448_KEY_GEN" "EC:X448" "X448" \
+                "${TSTCRTN}" "${KEYID}" "${URIKEYID}"
 
     X448PEERPUBURI="pkcs11:type=public;id=${URIKEYID}"
     X448PEERPRIURI="pkcs11:type=private;id=${URIKEYID}"
@@ -683,20 +641,8 @@ if [ "$SUPPORT_ML_DSA_KEY_GEN" -ne 0 ]; then
     get_next_keyid
     TSTCRTN="mlDsa"
 
-    if [ "$SUPPORT_ML_DSA_KEY_GEN" -eq 1 ]; then
-        ptool --keypairgen --key-type="ML-DSA-44" --id="$KEYID" \
-            --label="${TSTCRTN}" 2>&1
-    elif [ "$SUPPORT_ML_DSA_KEY_GEN" -eq 2 ]; then
-        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
-        ossl '
-        genpkey -propquery "provider=pkcs11"
-                -algorithm ML-DSA-44
-                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
-        OPENSSL_CONF=${BASE_OPENSSL_CONF}
-    else
-        echo "Bad value for SUPPORT_ML_DSA_KEY_GEN: $SUPPORT_ML_DSA_KEY_GEN"
-        exit 1
-    fi
+    gen_keypair "$SUPPORT_ML_DSA_KEY_GEN" "ML-DSA-44" "ML-DSA-44" \
+                "${TSTCRTN}" "${KEYID}" "${URIKEYID}"
     ca_sign $TSTCRTN "My ML-DSA Cert" "$KEYID"
 
     MLDSABASEURIWITHPINVALUE="pkcs11:id=${URIKEYID}?pin-value=${PINVALUE}"
@@ -719,21 +665,8 @@ if [ "$SUPPORT_ML_KEM_KEY_GEN" -ne 0 ]; then
     get_next_keyid
     TSTCRTN="mlKem"
 
-    if [ "$SUPPORT_ML_KEM_KEY_GEN" -eq 1 ]; then
-        ptool --keypairgen --key-type="ML-KEM-512" --id="$KEYID" \
-            --label="${TSTCRTN}" 2>&1
-
-    elif [ "$SUPPORT_ML_KEM_KEY_GEN" -eq 2 ]; then
-        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
-        ossl '
-        genpkey -propquery "provider=pkcs11"
-                -algorithm ML-KEM-512
-                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
-        OPENSSL_CONF=${BASE_OPENSSL_CONF}
-    else
-        echo "Bad value for SUPPORT_ML_KEM_KEY_GEN: $SUPPORT_ML_KEM_KEY_GEN"
-        exit 1
-    fi
+    gen_keypair "$SUPPORT_ML_KEM_KEY_GEN" "ML-KEM-512" "ML-KEM-512" \
+                "${TSTCRTN}" "${KEYID}" "${URIKEYID}"
 
     MLKEMBASEURIWITHPINVALUE="pkcs11:id=${URIKEYID}?pin-value=${PINVALUE}"
     MLKEMBASEURIWITHPINSOURCE="pkcs11:id=${URIKEYID}?pin-source=file:${PINFILE}"
@@ -753,20 +686,8 @@ if [ "$SUPPORT_SLH_DSA_KEY_GEN" -ne 0 ]; then
     get_next_keyid
     TSTCRTN="slhDsa"
 
-    if [ "$SUPPORT_SLH_DSA_KEY_GEN" -eq 1 ]; then
-        ptool --keypairgen --key-type="SLH-DSA-SHAKE-128S" --id="$KEYID" \
-            --label="${TSTCRTN}" 2>&1
-    elif [ "$SUPPORT_SLH_DSA_KEY_GEN" -eq 2 ]; then
-        OPENSSL_CONF=${URIPEM_OPENSSL_CONF}
-        ossl '
-        genpkey -propquery "provider=pkcs11"
-                -algorithm SLH-DSA-SHAKE-128s
-                -pkeyopt "pkcs11_uri:pkcs11:object=${TSTCRTN};id=${URIKEYID}"'
-        OPENSSL_CONF=${BASE_OPENSSL_CONF}
-    else
-        echo "Bad value for SUPPORT_SLH_DSA_KEY_GEN: $SUPPORT_SLH_DSA_KEY_GEN"
-        exit 1
-    fi
+    gen_keypair "$SUPPORT_SLH_DSA_KEY_GEN" "SLH-DSA-SHAKE-128S" "SLH-DSA-SHAKE-128s" \
+                "${TSTCRTN}" "${KEYID}" "${URIKEYID}"
     ca_sign $TSTCRTN "My SLH-DSA Cert" "$KEYID"
 
     SLHDSABASEURIWITHPINVALUE="pkcs11:id=${URIKEYID}?pin-value=${PINVALUE}"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -125,90 +125,13 @@ else
     exit 1
 fi
 
-if [ "${SUPPRESS_ED25519}" -ne 1 ]; then
-    if check_mechanism "EDDSA" || check_mechanism "mechtype-0x1057"; then
-        SUPPORT_ED25519=1
-        if check_mechanism "EC-EDWARDS-KEY-PAIR-GEN"; then
-            SUPPORT_ED25519_KEY_GEN=1
-        elif check_mechanism "mechtype-0x1055"; then
-            SUPPORT_ED25519_KEY_GEN=2
-        else
-            SUPPORT_ED25519=0
-        fi
-    fi
-fi
-if [ "${SUPPRESS_ED448}" -ne 1 ]; then
-    if check_mechanism "EDDSA" || check_mechanism "mechtype-0x1057"; then
-        SUPPORT_ED448=1
-        if check_mechanism "EC-EDWARDS-KEY-PAIR-GEN"; then
-            SUPPORT_ED448_KEY_GEN=1
-        elif check_mechanism "mechtype-0x1055"; then
-            SUPPORT_ED448_KEY_GEN=2
-        else
-            SUPPORT_ED448=0
-        fi
-    fi
-fi
-if [ "${SUPPRESS_X25519}" -ne 1 ]; then
-    if check_mechanism "ECDH1-DERIVE" || check_mechanism "mechtype-0x1050"; then
-        SUPPORT_X25519=1
-        if check_mechanism "EC-MONTGOMERY-KEY-PAIR-GEN"; then
-            SUPPORT_X25519_KEY_GEN=1
-        elif check_mechanism "mechtype-0x1050"; then
-            SUPPORT_X25519_KEY_GEN=2
-        else
-            SUPPORT_X25519=0
-        fi
-    fi
-fi
-if [ "${SUPPRESS_X448}" -ne 1 ]; then
-    if check_mechanism "ECDH1-DERIVE" || check_mechanism "mechtype-0x1050"; then
-        SUPPORT_X448=1
-        if check_mechanism "EC-MONTGOMERY-KEY-PAIR-GEN"; then
-            SUPPORT_X448_KEY_GEN=1
-        elif check_mechanism "mechtype-0x1050"; then
-            SUPPORT_X448_KEY_GEN=2
-        else
-            SUPPORT_X448=0
-        fi
-    fi
-fi
-if [ "${SUPPRESS_ML_DSA}" -ne 1 ]; then
-    if check_mechanism "ML-DSA" || check_mechanism "mechtype-0x1D"; then
-        SUPPORT_ML_DSA=1
-        if check_mechanism "ML-DSA-KEY-PAIR-GEN"; then
-            SUPPORT_ML_DSA_KEY_GEN=1
-        elif check_mechanism "mechtype-0x1C"; then
-            SUPPORT_ML_DSA_KEY_GEN=2
-        else
-            SUPPORT_ML_DSA=0
-        fi
-    fi
-fi
-if [ "${SUPPRESS_ML_KEM}" -ne 1 ]; then
-    if check_mechanism "ML-KEM" || check_mechanism "mechtype-0x17"; then
-        SUPPORT_ML_KEM=1
-        if check_mechanism "ML-KEM-KEY-PAIR-GEN"; then
-            SUPPORT_ML_KEM_KEY_GEN=1
-        elif check_mechanism "mechtype-0xF"; then
-            SUPPORT_ML_KEM_KEY_GEN=2
-        else
-            SUPPORT_ML_KEM=0
-        fi
-    fi
-fi
-if [ "${SUPPRESS_SLH_DSA}" -ne 1 ]; then
-    if ! check_mechanism "SLH-DSA" || check_mechanism "mechtype-0x2E"; then
-        SUPPORT_SLH_DSA=1
-        if check_mechanism "SLH-DSA-KEY-PAIR-GEN"; then
-            SUPPORT_SLH_DSA_KEY_GEN=1
-        elif check_mechanism "mechtype-0x2D"; then
-            SUPPORT_SLH_DSA_KEY_GEN=2
-        else
-            SUPPORT_SLH_DSA=0
-        fi
-    fi
-fi
+check_algorithm_support "ED25519" "EDDSA" "mechtype-0x1057" "EC-EDWARDS-KEY-PAIR-GEN" "mechtype-0x1055"
+check_algorithm_support "ED448" "EDDSA" "mechtype-0x1057" "EC-EDWARDS-KEY-PAIR-GEN" "mechtype-0x1055"
+check_algorithm_support "X25519" "ECDH1-DERIVE" "mechtype-0x1050" "EC-MONTGOMERY-KEY-PAIR-GEN" "mechtype-0x1050"
+check_algorithm_support "X448" "ECDH1-DERIVE" "mechtype-0x1050" "EC-MONTGOMERY-KEY-PAIR-GEN" "mechtype-0x1050"
+check_algorithm_support "ML_DSA" "ML-DSA" "mechtype-0x1D" "ML-DSA-KEY-PAIR-GEN" "mechtype-0x1C"
+check_algorithm_support "ML_KEM" "ML-KEM" "mechtype-0x17" "ML-KEM-KEY-PAIR-GEN" "mechtype-0xF"
+check_algorithm_support "SLH_DSA" "SLH-DSA" "mechtype-0x2E" "SLH-DSA-KEY-PAIR-GEN" "mechtype-0x2D"
 
 if [[ "${PKCS11_PROVIDER_FORCE_FIPS_MODE}" = "1" ]]; then
     # temporarily suppress symmetric tests in FIPS mode as no FIPS provider

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -665,7 +665,7 @@ if [ "$SUPPORT_ML_KEM_KEY_GEN" -ne 0 ]; then
     get_next_keyid
     TSTCRTN="mlKem"
 
-    gen_keypair "$SUPPORT_ML_KEM_KEY_GEN" "ML-KEM-512" "ML-KEM-512" \
+    gen_keypair "$SUPPORT_ML_KEM_KEY_GEN" "ML-KEM-768" "ML-KEM-768" \
                 "${TSTCRTN}" "${KEYID}" "${URIKEYID}"
 
     MLKEMBASEURIWITHPINVALUE="pkcs11:id=${URIKEYID}?pin-value=${PINVALUE}"

--- a/tests/softhsm-init.sh
+++ b/tests/softhsm-init.sh
@@ -76,10 +76,6 @@ export SUPPORT_ALLOWED_MECHANISMS=1
 # softhsm loops into itself badly on symmetric operation
 export SUPPORT_SYMMETRIC=0
 
-export SUPPORT_ML_DSA=0
-export SUPPORT_ML_KEM=0
-export SUPPORT_SLH_DSA=0
-
 # Montgomery curves are not supported in softhsm
 export SUPPORT_X25519=0
 export SUPPORT_X448=0

--- a/tests/softokn-init.sh
+++ b/tests/softokn-init.sh
@@ -29,17 +29,15 @@ export TOKENCONFIGVARS="export NSS_LIB_PARAMS=configDir=${TOKDIR}"
 
 export TESTPORT="30000"
 
-# Edward curves are not supported in NSS yet
-export SUPPORT_ED25519=0
-export SUPPORT_ED448=0
+# Edward curves are not well supported in NSS, Ed25519 requires a special OID
+# for generation in ECParams, while Ed448 is not supported at all
+export SUPPRESS_ED25519=1
+export SUPPRESS_ED448=1
 
-# Montgomery curves are not supported in NSS yet
-export SUPPORT_X25519=0
-export SUPPORT_X448=0
-
-export SUPPORT_ML_DSA=0
-export SUPPORT_ML_KEM=0
-export SUPPORT_SLH_DSA=0
+# Montgomery curves are not supported in NSS yet, but there is no way to
+# autodetect it
+export SUPPRESS_X25519=1
+export SUPPRESS_X448=1
 
 export SUPPORT_BLOCK_MODES="CBC CTR ECB"
 export SUPPORT_OPERATION_STATE=1

--- a/tests/tmlkem
+++ b/tests/tmlkem
@@ -15,7 +15,7 @@ title LINE "Print ML-KEM Public key from private"
 ossl 'pkey -in $MLKEMPRIURI -pubout -text' $helper_emit
 output="$helper_output"
 FAIL=0
-echo "$output" | grep "ML-KEM-512 Public Key" > /dev/null 2>&1 || FAIL=1
+echo "$output" | grep "ML-KEM-768 Public Key" > /dev/null 2>&1 || FAIL=1
 if [ $FAIL -eq 1 ]; then
     echo "Could not extract public key from private"
     echo
@@ -36,7 +36,7 @@ title PARA "Match private ML-KEM key against public key (commutativity)"
 $CHECKER "${TESTBLDDIR}/tcmpkeys" "${TMPPDIR}"/mlkemout.pub "$MLKEMPRIURI"
 
 title PARA "Test Key generation from C API"
-output=$($CHECKER "${TESTBLDDIR}"/tgenkey "ML-KEM-768" 2>&1 || true)
+output=$($CHECKER "${TESTBLDDIR}"/tgenkey "ML-KEM-1024" 2>&1 || true)
 FAIL=0
 echo "$output" | grep "Performed tests: 1" || FAIL=1
 if [ $FAIL -ne 0 ]; then

--- a/tests/tpem_encoder
+++ b/tests/tpem_encoder
@@ -175,7 +175,7 @@ if [[ -n "${MLKEMPRIURI}" ]]; then
     make-uri-pem "${MLKEMPRIURI}" "${TMPPDIR}/mlkempriuri-pkey.pem"
     ossl 'pkey -in "${TMPPDIR}/mlkempriuri-pkey.pem" -noout'
 
-    export ALGORITHM=ML-KEM-512
+    export ALGORITHM=ML-KEM-768
     ossl '
     genpkey -propquery "provider=pkcs11"
             -algorithm "${ALGORITHM}"

--- a/tests/tpkey.c
+++ b/tests/tpkey.c
@@ -323,7 +323,8 @@ static void run_ml_kem_tests(void)
     };
 
     const struct kem_test_data kem_tests[] = {
-        { "ML-KEM-512", "ML-KEM-512 Pkey KEM Test" },
+        /* Temporarily disable ML-KEM-512 as NSS does not support it */
+        /* { "ML-KEM-512", "ML-KEM-512 Pkey KEM Test" }, */
         { "ML-KEM-768", "ML-KEM-768 Pkey KEM Test" },
         { "ML-KEM-1024", "ML-KEM-1024 Pkey KEM Test" },
     };


### PR DESCRIPTION
#### Description

Use pkcs11-tool -M to do some more heavy lifting and auto-detection of what token supports and what pkcs11-tool supports

For keypair generation we'll have to also wait until https://github.com/OpenSC/OpenSC/pull/3795 makes into Fedora, but the fallback to openssl will work in the meanwhile.

Fixes #758

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] Code modified for feature
- [x] Test suite updated with functionality tests
- [x] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
