### PR TITLE
Add test for explicit PKCS#11 provider loading

### DIFF
--- a/tests/loadprov.c
+++ b/tests/loadprov.c
@@ -1,0 +1,101 @@
+/* Copyright (C) 2026 Simo Sorce <simo@redhat.com>
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <openssl/provider.h>
+#include <openssl/evp.h>
+#include <openssl/store.h>
+#include "util.h"
+
+int main(int argc, char *argv[])
+{
+#if defined(OSSL_PROVIDER_load_ex)
+    OSSL_PROVIDER *prov = NULL;
+    EVP_PKEY *key = NULL;
+    EVP_MD_CTX *md_ctx = NULL;
+    const unsigned char data[] = "Sign Me!";
+    unsigned char *sig = NULL;
+    size_t siglen = 0;
+    OSSL_PARAM params[5];
+    const char *module = getenv("PKCS11_PROVIDER_MODULE");
+    const char *pin = getenv("PINVALUE");
+    const char *libspath = getenv("LIBSPATH");
+    int p = 0;
+    int ret;
+
+    if (module == NULL) {
+        PRINTERR("PKCS11_PROVIDER_MODULE environment variable is absent\n");
+        exit(EXIT_FAILURE);
+    }
+    if (pin == NULL) {
+        PRINTERR("PINVALUE environment variable is absent\n");
+        exit(EXIT_FAILURE);
+    }
+    if (libspath == NULL) {
+        PRINTERR("LIBSPATH environment variable is absent\n");
+        exit(EXIT_FAILURE);
+    }
+
+    params[p++] = OSSL_PARAM_construct_utf8_string("pkc11-module-path",
+                                                   (char *)module, 0);
+    params[p++] = OSSL_PARAM_construct_utf8_string("pkcs11-module-token-pin",
+                                                   (char *)pin, 0);
+    params[p++] = OSSL_PARAM_construct_utf8_string(
+        "pkcs11-module-encode-provider-uri-to-pem", (char *)"true", 0);
+    params[p++] = OSSL_PARAM_construct_utf8_string(
+        "pkcs11-module-load-behavior", (char *)"early", 0);
+    params[p++] = OSSL_PARAM_construct_end();
+
+    if (!OSSL_PROVIDER_available(NULL, "default")) {
+        PRINTERR("Default provider is not loaded\n");
+        exit(EXIT_FAILURE);
+    }
+
+    OSSL_PROVIDER_set_default_search_path(NULL, libspath);
+
+    prov = OSSL_PROVIDER_load_ex(NULL, "pkcs11", params);
+    if (prov == NULL) {
+        PRINTERROSSL("Failed to load pkcs11 provider\n");
+        exit(EXIT_FAILURE);
+    }
+
+    key = util_gen_key("RSA 2048", "tloadprov test key");
+    if (key == NULL) {
+        PRINTERROSSL("Failed to generate key\n");
+        exit(EXIT_FAILURE);
+    }
+
+    siglen = EVP_PKEY_get_size(key);
+    sig = OPENSSL_zalloc(siglen);
+    if (sig == NULL) {
+        PRINTERROSSL("Failed to allocate signature buffer\n");
+        exit(EXIT_FAILURE);
+    }
+
+    md_ctx = EVP_MD_CTX_new();
+    if (md_ctx == NULL) {
+        PRINTERROSSL("Failed to create EVP_MD_CTX\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = EVP_DigestSignInit_ex(md_ctx, NULL, "SHA256", NULL, NULL, key, NULL);
+    if (ret != 1) {
+        PRINTERROSSL("Failed to init EVP_DigestSign\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = EVP_DigestSign(md_ctx, sig, &siglen, data, sizeof(data));
+    if (ret != 1) {
+        PRINTERROSSL("Failed to perform EVP_DigestSign\n");
+        exit(EXIT_FAILURE);
+    }
+
+    EVP_MD_CTX_free(md_ctx);
+    OPENSSL_free(sig);
+    EVP_PKEY_free(key);
+    OSSL_PROVIDER_unload(prov);
+#endif
+    PRINTERR("ALL A-OK!\n");
+    exit(EXIT_SUCCESS);
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,6 +30,7 @@ endif
 test_env = environment({
   'TEST_PATH': meson.current_source_dir(),
   'TESTBLDDIR': meson.current_build_dir(),
+  'LIBSPATH': meson.project_build_root() / 'src',
 })
 
 if get_option('enable_explicit_EC_test')
@@ -112,6 +113,7 @@ test_programs = {
   'tecx': ['tecx.c', 'util.c'],
   'tskey-kdf': ['tskey_kdf.c', 'util.c'],
   'taead': ['taead.c', 'util.c'],
+  'loadprov': ['loadprov.c', 'util.c'],
 }
 
 test_executables = []

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -236,4 +236,11 @@ if [ $FAIL -ne 0 ]; then
     exit 1
 fi
 
+title PARA "Test Loading Provider with config"
+ORIG_OPENSSL_CONF=${OPENSSL_CONF}
+sed "/pkcs11/d" "${OPENSSL_CONF}" > "${OPENSSL_CONF}.nopkcs11"
+OPENSSL_CONF=${OPENSSL_CONF}.nopkcs11
+$CHECKER "${TESTBLDDIR}/loadprov"
+OPENSSL_CONF=${ORIG_OPENSSL_CONF}
+
 exit 0

--- a/tests/util.h
+++ b/tests/util.h
@@ -3,6 +3,7 @@
    SPDX-License-Identifier: Apache-2.0 */
 
 #include <stdio.h>
+#include <openssl/err.h>
 
 #define PRINTERR(...) \
     do { \


### PR DESCRIPTION
#### Description

Add a new `loadprov` test program to verify that the PKCS#11 provider can be explicitly loaded via `OSSL_PROVIDER_load_ex()` with custom OSSL parameters.

Update `meson.build` and `tbasic` to run this test using an OpenSSL config file where the PKCS#11 provider configuration is stripped out.

Assisted-by: Gemini:Gemini 3.6 Flash

Fixes #513

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [ ] Code modified for feature
- [x] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
