### PR TITLE
Add way to set maximum allowed pin length

### DIFF
--- a/docs/provider-pkcs11.7.md
+++ b/docs/provider-pkcs11.7.md
@@ -263,6 +263,22 @@ Default: none
 
 ```pkcs11-module-default-slot-id = 12345```
 
+## pkcs11-max-pin-length
+
+Set the maximum length (in bytes) allowed for token PINs when reading PINs from
+files or pin sources.
+
+If not explicitly set, it defaults to 256. During provider slot initialization,
+if any token reports a larger maximum PIN length (`ulMaxPinLen`), the limit is
+automatically adjusted to match the maximum value reported across available
+tokens.
+
+Default: 256
+
+Example:
+
+```pkcs11-max-pin-length = 512```
+
 
 ENVIRONMENT VARIABLES
 =====================

--- a/src/provider.c
+++ b/src/provider.c
@@ -35,6 +35,7 @@ struct p11prov_ctx {
 
     /* Configuration */
     char *pin;
+    CK_ULONG max_pin_length;
     int allow_export;
     int login_behavior;
     bool cache_pins;
@@ -686,6 +687,18 @@ int p11prov_ctx_login_behavior(P11PROV_CTX *ctx)
     return ctx->login_behavior;
 }
 
+CK_ULONG p11prov_ctx_max_pin_length(P11PROV_CTX *ctx)
+{
+    P11PROV_debug("max_pin_length = %lu", ctx->max_pin_length);
+    return ctx->max_pin_length;
+}
+
+void p11prov_ctx_set_max_pin_length(P11PROV_CTX *ctx, CK_ULONG max_pin_length)
+{
+    ctx->max_pin_length = max_pin_length;
+    P11PROV_debug("max_pin_length = %lu", ctx->max_pin_length);
+}
+
 bool p11prov_ctx_cache_pins(P11PROV_CTX *ctx)
 {
     P11PROV_debug("cache_pins = %s", ctx->cache_pins ? "true" : "false");
@@ -1285,6 +1298,7 @@ enum p11prov_cfg_enum {
     P11PROV_CFG_BLOCK_OPS,
     P11PROV_CFG_ASSUME_FIPS,
     P11PROV_CFG_DEFAULT_SLOT_ID,
+    P11PROV_CFG_MAX_PIN_LENGTH,
     P11PROV_CFG_SIZE,
 };
 
@@ -1305,6 +1319,7 @@ static struct p11prov_cfg_names {
     { "pkcs11-module-block-operations" },
     { "pkcs11-module-assume-fips" },
     { "pkcs11-module-default-slot-id" },
+    { "pkcs11-max-pin-length" },
 };
 
 int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
@@ -1383,6 +1398,25 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
         p11prov_ctx_free(ctx);
         return RET_OSSL_ERR;
     }
+
+    if (cfg[P11PROV_CFG_MAX_PIN_LENGTH] != NULL) {
+        CK_ULONG val = 0;
+        ret =
+            parse_ulong(ctx, cfg[P11PROV_CFG_MAX_PIN_LENGTH],
+                        strlen(cfg[P11PROV_CFG_MAX_PIN_LENGTH]), (void **)&val);
+        if (ret != 0) {
+            P11PROV_raise(ctx, CKR_GENERAL_ERROR, "Invalid value for %s: (%s)",
+                          p11prov_cfg_names[P11PROV_CFG_MAX_PIN_LENGTH].name,
+                          cfg[P11PROV_CFG_MAX_PIN_LENGTH]);
+            p11prov_ctx_free(ctx);
+            return RET_OSSL_ERR;
+        }
+        ctx->max_pin_length = val;
+    } else {
+        /* arbitrarily cap at 256 if not set, generally more than enough */
+        ctx->max_pin_length = 256;
+    }
+    P11PROV_debug("Max PIN length: %lu", ctx->max_pin_length);
 
     if (cfg[P11PROV_CFG_TOKEN_PIN] != NULL) {
         ret = p11prov_get_pin(ctx, cfg[P11PROV_CFG_TOKEN_PIN], &ctx->pin);

--- a/src/provider.h
+++ b/src/provider.h
@@ -105,6 +105,8 @@ int p11prov_ctx_allow_export(P11PROV_CTX *ctx);
 #define PUBKEY_LOGIN_ALWAYS 1
 #define PUBKEY_LOGIN_NEVER 2
 int p11prov_ctx_login_behavior(P11PROV_CTX *ctx);
+CK_ULONG p11prov_ctx_max_pin_length(P11PROV_CTX *ctx);
+void p11prov_ctx_set_max_pin_length(P11PROV_CTX *ctx, CK_ULONG max_pin_length);
 bool p11prov_ctx_cache_pins(P11PROV_CTX *ctx);
 
 enum p11prov_cache_keys {

--- a/src/slot.c
+++ b/src/slot.c
@@ -127,6 +127,7 @@ CK_RV p11prov_init_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX **slots)
     struct p11prov_slots_ctx *sctx;
     CK_RV ret;
     int err;
+    CK_ULONG max_pin_len = p11prov_ctx_max_pin_length(ctx);
 
     ck_info = p11prov_ctx_get_ck_info(ctx);
 
@@ -200,6 +201,11 @@ CK_RV p11prov_init_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX **slots)
             continue;
         }
 
+        if (slot->token.ulMaxPinLen != CK_UNAVAILABLE_INFORMATION
+            && slot->token.ulMaxPinLen > max_pin_len) {
+            max_pin_len = slot->token.ulMaxPinLen;
+        }
+
         sctx->slots[sctx->num] = slot;
         sctx->num++;
 
@@ -251,6 +257,10 @@ CK_RV p11prov_init_slots(P11PROV_CTX *ctx, P11PROV_SLOTS_CTX **slots)
 
         P11PROV_debug_slot(ctx, slot->id, &slot->slot, &slot->token,
                            slot->mechs, slot->nmechs, slot->profiles);
+    }
+
+    if (max_pin_len > 0) {
+        p11prov_ctx_set_max_pin_length(ctx, max_pin_len);
     }
 
 done:

--- a/src/util.c
+++ b/src/util.c
@@ -228,10 +228,12 @@ done:
 static int get_pin_file(P11PROV_CTX *ctx, const char *str, size_t len,
                         void **output)
 {
-    char pin[MAX_PIN_LENGTH + 1] = { 0 };
-    char *pinfile;
+    CK_ULONG max_pin_len = p11prov_ctx_max_pin_length(ctx);
+    char *pin = NULL;
+    char *pinfile = NULL;
     char *filename;
     BIO *fp;
+    char extra;
     int ret;
 
     ret = parse_attr(str, len, (uint8_t **)&pinfile, NULL);
@@ -249,15 +251,29 @@ static int get_pin_file(P11PROV_CTX *ctx, const char *str, size_t len,
         filename = pinfile;
     }
 
+    pin = OPENSSL_zalloc(max_pin_len + 1);
+    if (pin == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
     fp = BIO_new_file(filename, "r");
     if (fp == NULL) {
         P11PROV_debug("Failed to get pin from %s", filename);
         ret = ENOENT;
         goto done;
     }
-    ret = BIO_gets(fp, pin, sizeof(pin));
+    ret = BIO_read(fp, pin, max_pin_len + 1);
     if (ret <= 0) {
         P11PROV_debug("Failed to get pin from %s (%d)", filename, ret);
+        ret = EINVAL;
+        BIO_free(fp);
+        goto done;
+    }
+    if ((CK_ULONG)ret == max_pin_len + 1 && BIO_read(fp, &extra, 1) > 0) {
+        P11PROV_debug(
+            "Failed to get pin from %s, file is bigger than max allowed (%lu)",
+            filename, max_pin_len + 1);
         ret = EINVAL;
         BIO_free(fp);
         goto done;
@@ -273,14 +289,22 @@ static int get_pin_file(P11PROV_CTX *ctx, const char *str, size_t len,
         }
     }
 
-    *output = OPENSSL_strdup(pin);
-    if (*output == NULL) {
-        ret = ENOMEM;
+    if (pin[max_pin_len] != '\0') {
+        P11PROV_debug(
+            "Failed to get pin from %s, pin is longer than max length (%lu)",
+            filename, max_pin_len);
+        ret = EINVAL;
         goto done;
     }
 
+    *output = pin;
+    pin = NULL;
     ret = 0;
+
 done:
+    if (pin != NULL) {
+        OPENSSL_clear_free(pin, max_pin_len + 1);
+    }
     OPENSSL_free(pinfile);
     return ret;
 }

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -22,6 +22,7 @@ activate = 1
 
 [pkcs11_sect]
 module = @libtoollibs@/pkcs11@SHARED_EXT@
+#pkcs11-max-pin-length
 pkcs11-module-token-pin = file:@PINFILE@
 #pkcs11-module-default-slot-id
 ##TOKENOPTIONS

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -99,6 +99,30 @@ expect -c "spawn -noecho $CHECKER $OPENSSL pkey -in \"${PUBURI}\" -pubin -pubout
 
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
 
+title PARA "Test fetching public key with PIN source exceeding max length"
+ORIG_OPENSSL_CONF=${OPENSSL_CONF}
+sed -e "s/#pkcs11-max-pin-length/pkcs11-max-pin-length = 768/" -e "s/^pkcs11-module-token-pin.*$/##nopin/" "${OPENSSL_CONF}" > "${OPENSSL_CONF}.maxpin"
+OPENSSL_CONF=${OPENSSL_CONF}.maxpin
+
+LARGE_PIN_FILE="${TMPPDIR}/large_pin.txt"
+printf '%1024s\n' '' | tr ' ' 'A' > "${LARGE_PIN_FILE}"
+
+FAIL=0
+output=$($CHECKER "${OPENSSL}" pkey -in "${PRIURI};pin-source=file:${LARGE_PIN_FILE}" 2>&1) && FAIL=1
+if [ $FAIL -ne 0 ]; then
+    echo "Expected failure when PIN exceeds maximum length, but command succeeded"
+    exit 1
+fi
+echo "$output" | grep -iE "error|failed|cannot|unable|could not" > /dev/null 2>&1 || FAIL=2
+if [ $FAIL -eq 2 ]; then
+    echo "Command failed as expected, but did not produce an appropriate error message"
+    echo "Output was:"
+    echo "$output"
+    exit 1
+fi
+
+OPENSSL_CONF=${ORIG_OPENSSL_CONF}
+
 title PARA "Test EVP_PKEY_eq on public RSA key both on token"
 # shellcheck disable=SC2153 # PUBURIs is assigned
 $CHECKER "${TESTBLDDIR}/tcmpkeys" "$PUBURI" "$PUBURI"


### PR DESCRIPTION
#### Description
This pull request introduces the `pkcs11-max-pin-length` configuration option to allow user-defined maximum PIN lengths (defaulting to 256 bytes) and automatically adjusts the limit if tokens report a larger `ulMaxPinLen`. It updates PIN file reading routines to allocate memory dynamically and adds a test case in `tests/tbasic`.

Fixes #655 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [x] Test suite updated with negative tests
- [x] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
