### PR TITLE
Replace check_skip_login with needs_login

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -942,10 +942,24 @@ done:
     return ret;
 }
 
-static bool check_skip_login(P11PROV_CTX *ctx, P11PROV_SLOT *slot)
+static bool needs_login(P11PROV_CTX *ctx, P11PROV_SLOT *slot, bool reqlogin)
 {
-    return p11prov_ctx_login_behavior(ctx) != PUBKEY_LOGIN_ALWAYS
-           && !p11prov_slot_check_req_login(slot);
+    /* Check if provider configuration forces login for all public key operations */
+    if (p11prov_ctx_login_behavior(ctx) == PUBKEY_LOGIN_ALWAYS) {
+        return true;
+    }
+
+    /* Check if login was requested by the caller for this operation */
+    if (!reqlogin) {
+        return false;
+    }
+
+    /* Check if the token/slot requires login (e.g. CKF_LOGIN_REQUIRED flag) */
+    if (p11prov_slot_check_req_login(slot)) {
+        return true;
+    }
+
+    return false;
 }
 
 /* There are three possible ways to call this function.
@@ -1004,8 +1018,7 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
         if (ret != CKR_OK) {
             goto done;
         }
-        if ((reqlogin && !check_skip_login(provctx, slot))
-            || p11prov_ctx_login_behavior(provctx) == PUBKEY_LOGIN_ALWAYS) {
+        if (needs_login(provctx, slot, reqlogin)) {
             ret = slot_login(slot, uri, pw_cb, pw_cbarg, reqlogin, NULL);
             if (ret != CKR_OK) {
                 goto done;
@@ -1039,8 +1052,7 @@ CK_RV p11prov_get_session(P11PROV_CTX *provctx, CK_SLOT_ID *slotid,
                 /* keep going */
                 continue;
             }
-            if ((reqlogin && !check_skip_login(provctx, slot))
-                || p11prov_ctx_login_behavior(provctx) == PUBKEY_LOGIN_ALWAYS) {
+            if (needs_login(provctx, slot, reqlogin)) {
                 ret = slot_login(slot, uri, pw_cb, pw_cbarg, reqlogin, NULL);
                 if (ret != CKR_OK) {
                     /* keep going */

--- a/tests/openssl.cnf.in
+++ b/tests/openssl.cnf.in
@@ -24,12 +24,13 @@ activate = 1
 module = @libtoollibs@/pkcs11@SHARED_EXT@
 #pkcs11-max-pin-length
 pkcs11-module-token-pin = file:@PINFILE@
-#pkcs11-module-default-slot-id
 ##TOKENOPTIONS
-#pkcs11-module-encode-provider-uri-to-pem
 #pkcs11-module-allow-export
-#pkcs11-module-load-behavior
 #pkcs11-module-block-operations
+#pkcs11-module-default-slot-id
+#pkcs11-module-encode-provider-uri-to-pem
+#pkcs11-module-load-behavior
+#pkcs11-module-login-behavior
 activate = 1
 
 ####################################################################

--- a/tests/tbasic
+++ b/tests/tbasic
@@ -267,4 +267,20 @@ OPENSSL_CONF=${OPENSSL_CONF}.nopkcs11
 $CHECKER "${TESTBLDDIR}/loadprov"
 OPENSSL_CONF=${ORIG_OPENSSL_CONF}
 
+title PARA "Test PUBKEY_LOGIN_ALWAYS login behavior"
+ORIG_OPENSSL_CONF=${OPENSSL_CONF}
+sed -e "s/^pkcs11-module-token-pin.*$/##nopin/" -e "s/#pkcs11-module-login-behavior/pkcs11-module-login-behavior = always/" "${OPENSSL_CONF}" > "${OPENSSL_CONF}.loginalways"
+OPENSSL_CONF=${OPENSSL_CONF}.loginalways
+
+FAIL=0
+$CHECKER "${OPENSSL}" pkey -in "${PUBURI}" -pubin -pubout -out /dev/null 2>/dev/null && FAIL=1
+if [ $FAIL -ne 0 ]; then
+    echo "Expected failure when PIN is missing, but command succeeded"
+    exit 1
+fi
+
+ossl 'pkey -in "${PUBURI};pin-value=${PINVALUE}" -pubin -pubout -out /dev/null'
+
+OPENSSL_CONF=${ORIG_OPENSSL_CONF}
+
 exit 0


### PR DESCRIPTION
#### Description

Replace the inverted logic in check_skip_login and duplicate conditional checks with a clearer helper function, needs_login.

This consolidates the logic for checking context configuration, caller requests, and token slot flags into a single function, improving readability in p11prov_get_session.

Fixes #599 

#### Checklist
- [x] Code modified for feature
- [x] Test suite updated with functionality tests
- [x] Test suite updated with negative tests

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
