### PR TITLE
tests: Use github mirror for libssh

### DIFF
--- a/tests/integration/libssh.sh
+++ b/tests/integration/libssh.sh
@@ -49,7 +49,7 @@ libssh_setup()
 {
     title PARA "Clone, setup and build libssh"
 
-    git clone https://gitlab.com/libssh/libssh-mirror.git \
+    git clone https://github.com/libssh/libssh-mirror.git \
       "${WORKDIR}"/libssh-mirror
 
     mkdir "${WORKDIR}"/libssh-mirror/build


### PR DESCRIPTION
#### Description

Reaching gitlab from github actions is sometimes problematic, likely generally due to the amount of automated traffic these days so we mirror libssh also to github, which should be geographically closer.

#### Checklist

- [X] No Code modified for feature

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
