### PR TITLE
Restrict EC point conversion to OpenSSL <= 3.0.7

### DIFF
--- a/src/kmgmt/ec.c
+++ b/src/kmgmt/ec.c
@@ -314,7 +314,6 @@ static CK_RV p11prov_ec_get_find_attrs(
     EC_POINT *point = NULL;
     BN_CTX *bn_ctx = NULL;
     const OSSL_PARAM *p;
-    uint8_t pub_data[MAX_EC_PUB_KEY_SIZE];
     const char *curve_name = NULL;
     int curve_nid;
     unsigned char *ecparams = NULL;
@@ -358,7 +357,9 @@ static CK_RV p11prov_ec_get_find_attrs(
             goto done;
         }
 
+#if OPENSSL_VERSION_NUMBER <= 0x30000070L
         if (((char *)p->data)[0] == '\x02' || ((char *)p->data)[0] == '\x03') {
+            uint8_t pub_data[MAX_EC_PUB_KEY_SIZE];
             int plen;
 
             P11PROV_debug(
@@ -386,7 +387,9 @@ static CK_RV p11prov_ec_get_find_attrs(
             if (rv != CKR_OK) {
                 goto done;
             }
-        } else {
+        } else
+#endif
+        {
             rv = p11prov_kmgmt_param_data_to_attr(attrs, &numattrs,
                                                   CKA_P11PROV_PUB_KEY, p->data,
                                                   p->data_size, false);


### PR DESCRIPTION
#### Description

Compressed EC public key points only need manual decompression workarounds in OpenSSL versions 3.0.7 and earlier. Wrap the handling logic in a version check macro and move the local buffer allocation inside the conditional block.

Assisted-by: Gemini:Gemini 3.7 Flash

Fixes #781 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
