### PR TITLE
ci: Merge uncovered lines over the block of unannotated ones

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -475,6 +475,12 @@ jobs:
               git fetch origin ${{ github.base_ref }} --depth=1
           fi
 
+      - name: Test the Test Script
+        run: |
+          python3 scripts/coverage/run_tests.py \
+            scripts/coverage_report.sh \
+            scripts/coverage/
+
       - name: Merge coverage reports
         run: |
           # Find all downloaded .info files and build the merge arguments

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -37,6 +37,7 @@ Files: .github/*
        tests/fork-data.*
        scripts/clean-dist.sh
        scripts/coverage_report.sh
+       scripts/coverage/*
        .lcovrc
 Copyright: (C) 2022 - 2026 Simo Sorce <simo@redhat.com>
 License: Apache-2.0

--- a/scripts/coverage/gap_merge.test
+++ b/scripts/coverage/gap_merge.test
@@ -1,0 +1,13 @@
+/* EXPECTED
+### 🔍 Missing code coverage for this PR
+| File | Lines | Snippet |
+|---|---|---|
+| src/test.c | 3-5 | `            PRINTERR("Failed to compute default reference for '%s'\n",`<br>`                     tc->name);`<br>`            exit(EXIT_FAILURE);` |
+*/
+  | void test_func() {
++1|         if (derive_default_sshkdf(def_libctx, tc, expected, tc->out_len) != 0) {
++0|             PRINTERR("Failed to compute default reference for '%s'\n",
++ |                      tc->name);
++0|             exit(EXIT_FAILURE);
++ |         }
+  | }

--- a/scripts/coverage/negative_covered.test
+++ b/scripts/coverage/negative_covered.test
@@ -1,0 +1,12 @@
+/* EXPECTED
+### 🔍 Missing code coverage for this PR
+| File | Lines | Snippet |
+|---|---|---|
+| src/test.c | 2 | `    int uncovered_1 = 1;` |
+| src/test.c | 4 | `    int uncovered_2 = 2;` |
+*/
+  | void test_func() {
++0|     int uncovered_1 = 1;
++1|     int covered = 1;
++0|     int uncovered_2 = 2;
+  | }

--- a/scripts/coverage/run_tests.py
+++ b/scripts/coverage/run_tests.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+import os, sys, tempfile, subprocess, re, shutil, glob, difflib
+
+def run_test(script_path, test_file):
+    with open(test_file, 'r') as f:
+        lines = f.readlines()
+
+    expected = []
+    before_code, after_code, lcov_data = [], [], []
+    in_expected = False
+    after_line_num = 0
+
+    # 1. Parse the inline annotations
+    for line in lines:
+        if line.startswith('/* EXPECTED'):
+            in_expected = True
+            continue
+        if in_expected:
+            if line.strip() == '*/':
+                in_expected = False
+            else:
+                expected.append(line)
+            continue
+
+        # Match format: [ +|-| ] [hits| ] | code
+        match = re.match(r'^([+\-\s])([0-9\s]*)\|(.*)', line.rstrip('\n'))
+        if match:
+            pr_mod = match.group(1)       # +, -, or space
+            hits = match.group(2).strip() # 0, 1, or empty
+            code = match.group(3)[1:]
+
+            if pr_mod in ('-', ' '):
+                before_code.append(code)
+
+            if pr_mod in ('+', ' '):
+                after_line_num += 1
+                after_code.append(code)
+                if hits.isdigit():
+                    lcov_data.append(f"DA:{after_line_num},{hits}")
+
+    test_dir = tempfile.mkdtemp()
+
+    try:
+        # 2. Write the "After" file to disk so `sed` can read the snippets
+        src_file = os.path.join(test_dir, "src", "test.c")
+        os.makedirs(os.path.dirname(src_file))
+        with open(src_file, "w") as f:
+            f.write("\n".join(after_code) + "\n")
+
+        # 3. Generate the Unified Diff using Python, mimicking `git diff -U0`
+        diff_lines = list(difflib.unified_diff(
+            [l + "\n" for l in before_code],
+            [l + "\n" for l in after_code],
+            fromfile="a/src/test.c",
+            tofile="b/src/test.c",
+            n=0 # Context lines = 0 (Matches git diff -U0)
+        ))
+
+        diff_file = os.path.join(test_dir, "mock_diff.txt")
+        with open(diff_file, "w") as f:
+            f.write("".join(diff_lines))
+
+        # 4. Create a Fake `git` Executable
+        # When the bash script runs `git diff...`, it will run this instead!
+        fake_git = os.path.join(test_dir, "git")
+        with open(fake_git, "w") as f:
+            f.write("#!/bin/bash\n")
+            f.write(f"if [ \"$1\" = \"diff\" ]; then cat '{diff_file}'; fi\n")
+        os.chmod(fake_git, 0o755)
+
+        # 5. Write LCOV tracefile
+        lcov_file = os.path.join(test_dir, "coverage.info")
+        with open(lcov_file, "w") as f:
+            f.write("TN:\nSF:src/test.c\n")
+            f.write("\n".join(lcov_data) + "\n")
+            f.write("end_of_record\n")
+
+        # 6. Execute the Bash Script
+        summary_file = os.path.join(test_dir, "summary.md")
+        env = os.environ.copy()
+        # Inject our fake git into the PATH
+        env["PATH"] = f"{test_dir}:{env.get('PATH', '')}"
+        env["GITHUB_WORKSPACE"] = test_dir
+        env["GITHUB_EVENT_NAME"] = "push"
+        env["GITHUB_STEP_SUMMARY"] = summary_file
+
+        subprocess.run(["bash", script_path, lcov_file], env=env, stdout=subprocess.DEVNULL, cwd=test_dir)
+
+        # 7. Compare Outputs
+        with open(summary_file, "r") as f:
+            actual = f.read().strip()
+        expected_str = "".join(expected).strip()
+
+        if actual == expected_str:
+            print(f"✅ PASS: {os.path.basename(test_file)}")
+            return True
+        else:
+            print(f"❌ FAIL: {os.path.basename(test_file)}")
+            print("\n--- EXPECTED ---\n" + expected_str)
+            print("\n--- ACTUAL ---\n" + actual + "\n")
+            return False
+
+    finally:
+        shutil.rmtree(test_dir)
+
+if __name__ == '__main__':
+    script_path = os.path.abspath(sys.argv[1])
+    test_dir = sys.argv[2]
+
+    success = True
+    for test_file in sorted(glob.glob(os.path.join(test_dir, "*.test"))):
+        if not run_test(script_path, test_file):
+            success = False
+
+    sys.exit(0 if success else 1)

--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Parses LCOV tracefiles and annotates PRs with missing code coverage.
-# Usage: ./annotate_coverage.sh <path_to_lcov_file>
+# Usage: ./coverage_report.sh <path_to_lcov_file>
 
 set -euo pipefail
 
@@ -103,17 +103,22 @@ BEGIN {
 }
 /^DA:/ {
     line = $2; hits = $3
-    # Only track if the line is uncovered AND modified in this PR
-    if (rel_file != "" && changed_lines[rel_file ":" line] == 1 && hits == 0) {
-        if (start_line == 0) {
-            start_line = line
-            prev_line = line
-        } else if (line == prev_line + 1) {
-            prev_line = line # Extend the block
-        } else {
-            flush_block()    # Gap found! Print current block and start a new one
-            start_line = line
-            prev_line = line
+    if (rel_file != "") {
+        # Check if the line is uncovered AND modified in this PR
+        if (changed_lines[rel_file ":" line] == 1 && hits == 0) {
+            if (start_line == 0) {
+                start_line = line
+                prev_line = line
+            # Allow a gap of up to 5 lines (to bridge string literals / formatting)
+            } else if (line <= prev_line + 5) {
+                prev_line = line # Extend the block
+            } else {
+                flush_block()    # Gap too large! Print block and start a new one
+                start_line = line
+                prev_line = line
+            }
+        } else if (start_line != 0 && line > prev_line) {
+            flush_block()
         }
     }
 }

--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -60,7 +60,6 @@ function flush_block() {
         cmd = "sed -n \"" start_line "," prev_line "p\" " rel_file
         code_text = ""
         while ((cmd | getline seq_line) > 0) {
-            sub(/^[ \t]+/, "", seq_line)      # Strip leading whitespace
             sub(/[ \t]+$/, "", seq_line)      # Strip trailing whitespace
             gsub(/\|/, "\\|", seq_line)       # Escape table pipes
             gsub(/`/, "\x27", seq_line)       # Escape backticks


### PR DESCRIPTION
#### Description

There is no coverage data for multi-line function calls, which are very common in error logging, for example:

```
            PRINTERR("Failed to compute default reference for '%s'\n",
                     tc->name);
            exit(EXIT_FAILURE);
```

Before this change, this resulted in 2 separate warnings about uncovered code. This change adds some wiggle room (of up to 5 lines) between coverage reports that merge these two blocks into one and avoid noise.

#### Checklist

- [X] No code modified for feature

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
