### PR TITLE
Treat bignum RSA key attributes as big-endian when comparing.

### DIFF
--- a/src/obj/keymgmt.c
+++ b/src/obj/keymgmt.c
@@ -514,8 +514,10 @@ static int cmp_bn_attr(P11PROV_OBJ *key1, P11PROV_OBJ *key2,
         return rc;
     }
 
-    bx1 = BN_native2bn(x1->pValue, x1->ulValueLen, NULL);
-    bx2 = BN_native2bn(x2->pValue, x2->ulValueLen, NULL);
+    /* PKCS#11 values, like modulus and public exponent, are of type "Big
+       integer", unsigned integer most-significant byte first. */
+    bx1 = BN_bin2bn(x1->pValue, x1->ulValueLen, NULL);
+    bx2 = BN_bin2bn(x2->pValue, x2->ulValueLen, NULL);
 
     if (BN_cmp(bx1, bx2) == 0) {
         rc = RET_OSSL_OK;


### PR DESCRIPTION
#### Description

Closes #787

Treat RSA key attributes as big-endian when checking for key equality. Allows for key attributs, like CKA_PUBLIC_EXPONENT, that have leading zeros to compare equal to the same values without leading zeroes.

This is more correct with regards to the PKCS#11 standard.

<!--  The description should give a general overview of the goal of the PR.

Individual commit message should highlight important changes that people may
want to know about year later when sorting thorough as commits are the changelog.
-->

<!-- Note: it is best to make pull requests from a branch rather than from main -->

#### Checklist
- [x ] Code modified for feature

#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
