### PR TITLE
Remove WRAP and UNWRAP attributes from EC keys

### DIFF
--- a/src/kmgmt/ec.c
+++ b/src/kmgmt/ec.c
@@ -642,23 +642,21 @@ static void *p11prov_ec_gen(void *genctx, OSSL_CALLBACK *cb_fn, void *cb_arg)
     }
 
     /* always leave space for CKA_ID and CKA_LABEL */
-#define EC_PUBKEY_TMPL_SIZE 5
+#define EC_PUBKEY_TMPL_SIZE 4
     CK_ATTRIBUTE pubkey_template[EC_PUBKEY_TMPL_SIZE + COMMON_TMPL_SIZE] = {
         { CKA_TOKEN, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
         { CKA_DERIVE, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
         { CKA_VERIFY, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
-        { CKA_WRAP, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
         { CKA_EC_PARAMS, (CK_BYTE *)ctx->data.ec.ec_params,
           ctx->data.ec.ec_params_size },
     };
-#define EC_PRIVKEY_TMPL_SIZE 6
+#define EC_PRIVKEY_TMPL_SIZE 5
     CK_ATTRIBUTE privkey_template[EC_PRIVKEY_TMPL_SIZE + COMMON_TMPL_SIZE] = {
         { CKA_TOKEN, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
         { CKA_DERIVE, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
         { CKA_PRIVATE, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
         { CKA_SENSITIVE, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
         { CKA_SIGN, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
-        { CKA_UNWRAP, DISCARD_CONST(&val_true), sizeof(CK_BBOOL) },
         /* TODO?
          * CKA_SUBJECT
          * CKA_COPYABLE = true ?


### PR DESCRIPTION
#### Description

EC keys do not typically support direct key wrapping and unwrapping operations, and specifying these attributes can cause key generation to fail on some PKCS#11 tokens. Remove CKA_WRAP from the public key template and CKA_UNWRAP from the private key template.

Assisted-by: Gemini:Gemini 3.8 Flash

Fixes #791 

#### Checklist

<!-- replace [ ] with [x] to select -->
<!-- (delete not applicable items) -->

- [x] Code modified for feature
- [ ] Test suite updated with functionality tests
- [ ] Test suite updated with negative tests
- [ ] Documentation updated


#### Reviewer's checklist:

- [ ] Any issues marked for closing are addressed
- [ ] There is a test suite reasonably covering new functionality or modifications
- [ ] This feature/change has adequate documentation added
- [ ] Code conform to coding style that today cannot yet be enforced via the check style test
- [ ] Commits have short titles and sensible commit messages
